### PR TITLE
infra: dual-branch docs deployment (main + staging)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, staging ]
   workflow_dispatch: {}
 
 jobs:
@@ -19,10 +19,23 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Compute base path
+        id: base
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "base=/ColliderML/" >> $GITHUB_OUTPUT
+            echo "dest=." >> $GITHUB_OUTPUT
+          else
+            echo "base=/ColliderML/staging/" >> $GITHUB_OUTPUT
+            echo "dest=staging" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install docs dependencies
         run: npm ci --prefix docs
 
       - name: Build docs
+        env:
+          VITEPRESS_BASE: ${{ steps.base.outputs.base }}
         run: npm run --prefix docs docs:build
 
       - name: Deploy to GitHub Pages
@@ -31,4 +44,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/.vitepress/dist
           publish_branch: gh-pages
-
+          destination_dir: ${{ steps.base.outputs.dest }}
+          keep_files: true

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,13 +1,17 @@
 import { defineConfig } from 'vitepress'
 
+// Base path is branch-aware: `main` serves the canonical site at
+// `/ColliderML/`, `staging` (and PR previews) serve at `/ColliderML/staging/`.
+// The deploy workflow sets VITEPRESS_BASE accordingly; leave the default
+// for local `vitepress dev`.
+const base = process.env.VITEPRESS_BASE ?? '/ColliderML/'
+
 const config = defineConfig({
   title: 'ColliderML',
   description: 'A modern machine learning library for high-energy physics data analysis',
   lang: 'en-US',
   lastUpdated: true,
-  // Set base for GitHub Pages project site if repo is 'colliderml'.
-  // If using a custom domain or org/user site, adjust to '/'
-  base: '/ColliderML/',
+  base,
   
   // Ignore dead links for now (pages don't exist yet)
   ignoreDeadLinks: true,


### PR DESCRIPTION
## Summary

- Extend `deploy-docs.yml` to trigger on both `main` and `staging` branches
- `main` deploys to gh-pages root (`/ColliderML/`), `staging` deploys to `/ColliderML/staging/`
- `config.ts` reads `VITEPRESS_BASE` from the environment so both base paths work
- Uses `destination_dir` + `keep_files: true` so the two deploys don't clobber each other

This is prep infrastructure for the v0.4.0 migration — it needs to land on `main` before `staging` can be bootstrapped.

## Test plan

- [ ] Merge to main → verify canonical docs still deploy correctly at `/ColliderML/`
- [ ] Create staging branch → verify staging docs deploy to `/ColliderML/staging/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)