### PR TITLE
release: 0.4.0rc2 — widen Python support to 3.10+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/colliderml/__init__.py
+++ b/colliderml/__init__.py
@@ -31,7 +31,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.4.0"
+from importlib.metadata import PackageNotFoundError, version as _version
+
+try:
+    __version__ = _version("colliderml")
+except PackageNotFoundError:  # pragma: no cover — running from a source tree without metadata
+    __version__ = "0.0.0+unknown"
 
 # Subpackages that were in v0.3.1 and are always available.
 from . import core

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.10 or 3.11
+- Python 3.10 or newer
 - pip or conda
 
 ## Install from PyPI
@@ -121,7 +121,7 @@ ColliderML datasets are public and don't require authentication. However, if you
 
 ### Python Version Issues
 
-ColliderML requires Python 3.10 or 3.11. Check your version:
+ColliderML requires Python 3.10 or newer. Check your version:
 
 ```bash
 python --version

--- a/docs/guide/remote-simulation.md
+++ b/docs/guide/remote-simulation.md
@@ -26,7 +26,7 @@ dataset and charges zero credits.
 
 ## Prerequisites
 
-1. **Python 3.10 or 3.11**.
+1. **Python 3.10 or newer**.
 2. **The remote extra**:
    ```bash
    pip install "colliderml[remote]"

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -25,7 +25,7 @@ A typical iteration loop — `simulate → inspect → tweak → simulate again`
 
 ## Prerequisites
 
-1. **Python 3.10 or 3.11** — see [Installation](./installation.md).
+1. **Python 3.10 or newer** — see [Installation](./installation.md).
 2. **Either Docker or Podman** on your `$PATH`. The library auto-detects
    whichever is installed; Docker is preferred if both are present.
 3. **Disk headroom**:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="colliderml",
-    version="0.4.0rc1",
+    version="0.4.0rc2",
     description="A modern machine learning library for high-energy physics data analysis",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
@@ -10,7 +10,7 @@ setup(
     author_email="dtmurnane@lbl.gov",
     url="https://github.com/OpenDataDetector/ColliderML",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    python_requires=">=3.10,<3.12",
+    python_requires=">=3.10",
     install_requires=[
         "datasets>=2.14.0",
         "huggingface_hub>=0.20.0",
@@ -65,6 +65,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering :: Physics",
     ],
     project_urls={


### PR DESCRIPTION
## Summary

Ship `v0.4.0rc2` after the rc1 install surfaced a packaging bug: `python_requires=">=3.10,<3.12"` excluded Python 3.12+, which blocked the backend image (python:3.12-slim) from installing the rc.

Changes:
- **setup.py** — drop `<3.12` upper cap on `python_requires`; add `3.12` + `3.13` trove classifiers; bump version to `0.4.0rc2`.
- **colliderml/__init__.py** — read `__version__` from `importlib.metadata` instead of hardcoding (was reporting `0.4.0` after installing `0.4.0rc1`).
- **tests.yml** — expand CI matrix to `3.10 / 3.11 / 3.12 / 3.13` so we actually verify the wider support.
- **docs/guide/*.md** — update "Python 3.10 or 3.11" wording.

All 113 fast tests still pass locally on 3.11.

## Post-merge

1. Create GitHub release `v0.4.0rc2` (marked pre-release). `publish-pypi.yml` auto-publishes.
2. Verify `pypi.org/project/colliderml/0.4.0rc2/`.
3. Resume backend build + tutorial dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)