### PR TITLE
release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
-## [0.4.0] - 2026-04-09
+## [0.4.0] - 2026-05-27
 
 ### Added
+- [dataset] HF-native leaderboard score store: `huggingface.co/datasets/CERN/colliderml-benchmark-results` receives one JSON per submission at `results/<task>/<user>/<sha12>.json`. Pairs with the new client-side `colliderml.tasks.submit(..., model_repo_id=...)` which also lands a `.eval_results/colliderml_<task>.yaml` on the user's HF model repo so scores auto-render on the model card.
+- [dataset] `CERN/ColliderML-Release-1` configs reorganised: per-pileup/per-object split (`{channel}_{pileup}_{tracker_hits,particles,calo_hits,tracks}`) replaces the prior monolithic per-channel layout. Enables event-range-scoped downloads (the `tracking` eval split is now ~700 MB to pull instead of multiple GB).
 - [library] Top-level `colliderml.load(dataset, *, tables, max_events, event_range, …)` — a one-liner that downloads missing parquets on demand, then loads them with the existing Polars backend. Uses the same `<channel>_<pileup>` shorthand as the benchmark task runner.
 - [library] `colliderml.simulate` subpackage — run the full Pythia / MadGraph / Geant4 / ACTS pipeline locally inside a Docker or Podman container, or submit to the SaaS backend with `remote=True`. Local simulate auto-clones the companion `colliderml-production` repo at a pinned git ref for pipeline scripts, mirroring the existing ODD and MG5aMC_PY8_interface cache pattern. Ships a bundled preset catalogue (`ttbar-quick`, `higgs-portal-quick`, `ttbar-dev`, `ttbar-benchmark`, …) accessible via `colliderml.simulate.load_presets()`.
 - [library] `colliderml.remote` subpackage — HTTP client for the ColliderML SaaS backend service. Exposes `submit`, `status`, `wait_for`, `get_me`, `balance`, and a `RemoteSubmission` dataclass. Authentication is via a HuggingFace token resolved from the environment or the hub's saved credentials.

--- a/colliderml/simulate/docker.py
+++ b/colliderml/simulate/docker.py
@@ -37,11 +37,11 @@ COLLIDERML_PRODUCTION_REPO = "https://github.com/OpenDataDetector/colliderml-pro
 #: this. Can also be overridden per-invocation via ``COLLIDERML_PRODUCTION_REF``.
 #:
 #: .. note::
-#:    During the v0.4.0 migration window this tracks ``staging`` so local
-#:    sim works against the active branch; once ``pipeline-v0.1.0`` is
-#:    tagged in the production repo (Phase E of the migration), bump this
-#:    constant to the tag.
-COLLIDERML_PRODUCTION_REF = "staging"
+#:    For v0.4.0+ this is pinned to the ``pipeline-v0.1.0`` tag on the
+#:    colliderml-production repo so local sim is reproducible across
+#:    upstream pipeline changes. Bump in lockstep with future pipeline
+#:    tags when the upstream cuts a new pipeline release.
+COLLIDERML_PRODUCTION_REF = "pipeline-v0.1.0"
 
 #: Environment variable override for the pinned ref (useful for testing
 #: against an in-flight branch of the production repo).

--- a/colliderml/simulate/presets.yaml
+++ b/colliderml/simulate/presets.yaml
@@ -53,9 +53,8 @@ presets:
     pileup: 200
     description: "Higgs portal, 1000 events, full pileup (benchmark-scale)"
 
-  # --- Single-particle debugging ------------------------------------------
-  single-muon:
-    channel: single_muon
-    events: 100
-    pileup: 0
-    description: "Single muon gun, 100 events, no pileup (~5 min)"
+# NOTE: the `single-muon` preset has been removed in v0.4.0. The
+# production single-muon dataset uses an ACTS particle-gun generator
+# (scripts/simulation/particlegun_gen.py), but pipeline.py currently
+# routes single_muon through pythia_generation. Will be reintroduced
+# in v0.4.1 once the channel-stage routing is fixed.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
-## [0.4.0] - 2026-04-09
+## [0.4.0] - 2026-05-27
 
 ### Added
+- [dataset] HF-native leaderboard score store: `huggingface.co/datasets/CERN/colliderml-benchmark-results` receives one JSON per submission at `results/<task>/<user>/<sha12>.json`. Pairs with the new client-side `colliderml.tasks.submit(..., model_repo_id=...)` which also lands a `.eval_results/colliderml_<task>.yaml` on the user's HF model repo so scores auto-render on the model card.
+- [dataset] `CERN/ColliderML-Release-1` configs reorganised: per-pileup/per-object split (`{channel}_{pileup}_{tracker_hits,particles,calo_hits,tracks}`) replaces the prior monolithic per-channel layout. Enables event-range-scoped downloads (the `tracking` eval split is now ~700 MB to pull instead of multiple GB).
 - [library] Top-level `colliderml.load(dataset, *, tables, max_events, event_range, …)` — a one-liner that downloads missing parquets on demand, then loads them with the existing Polars backend. Uses the same `<channel>_<pileup>` shorthand as the benchmark task runner.
 - [library] `colliderml.simulate` subpackage — run the full Pythia / MadGraph / Geant4 / ACTS pipeline locally inside a Docker or Podman container, or submit to the SaaS backend with `remote=True`. Local simulate auto-clones the companion `colliderml-production` repo at a pinned git ref for pipeline scripts, mirroring the existing ODD and MG5aMC_PY8_interface cache pattern. Ships a bundled preset catalogue (`ttbar-quick`, `higgs-portal-quick`, `ttbar-dev`, `ttbar-benchmark`, …) accessible via `colliderml.simulate.load_presets()`.
 - [library] `colliderml.remote` subpackage — HTTP client for the ColliderML SaaS backend service. Exposes `submit`, `status`, `wait_for`, `get_me`, `balance`, and a `RemoteSubmission` dataclass. Authentication is via a HuggingFace token resolved from the environment or the hub's saved credentials.

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -113,8 +113,8 @@ that bundles MadGraph, Pythia, Geant4 + ddsim, and ACTS. The
 hard-scatter generation → parton shower → detector simulation →
 track reconstruction — in a single call.
 
-For this chapter we use the `single-muon` preset, the fastest (~5
-minutes on a modern laptop).
+For this chapter we use the `higgs-portal-quick` preset — ten
+Higgs-portal events with low pileup, ~10 minutes on a modern laptop.
 
 ```python
 from colliderml.simulate import load_presets
@@ -123,7 +123,7 @@ import colliderml
 for name, cfg in load_presets().items():
     print(f"  {name:24}  channel={cfg['channel']:14} events={cfg['events']:>4} pileup={cfg['pileup']}")
 
-result = colliderml.simulate(preset="single-muon", quiet=True)
+result = colliderml.simulate(preset="higgs-portal-quick", quiet=True)
 print("run directory:", result.run_dir)
 print("stages run:   ", [s.name for s in result.stages])
 ```
@@ -385,7 +385,7 @@ the backend score it.
 
 The ColliderML model zoo is a thin HuggingFace Hub filter: any model
 on the Hub tagged `colliderml` shows up in
-[`spaces/model-zoo`](https://huggingface.co/spaces/OpenDataDetector/colliderml-model-zoo).
+[`spaces/model-zoo`](https://huggingface.co/spaces/murnanedaniel/colliderml-model-zoo).
 There's no backend registry, no approval process — the `tag` is the
 contract. Publishing is a standard `huggingface_hub.create_repo` +
 `upload_folder`.
@@ -470,7 +470,7 @@ from huggingface_hub import create_repo, upload_folder
 frames = colliderml.load("ttbar_pu0", tables=["tracker_hits"], max_events=200)
 
 # 2. Run the pipeline locally
-result = colliderml.simulate(preset="single-muon")
+result = colliderml.simulate(preset="higgs-portal-quick")
 
 # 3. Submit a remote simulation
 sub = remote.submit(channel="ttbar", events=10_000, pileup=200)

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,11 +67,11 @@ Use the configurator below to customize your dataset selection and generate the 
 If there are errors or unexpected behavior, please [open an issue](https://github.com/OpenDataDetector/ColliderML/issues) on the GitHub repository.
 <!-- CHANGELOG:DATASET:START -->
 ::: details Dataset Changelog (latest 5)
+- (0.4.0 — 2026-05-27) - HF-native leaderboard score store: `huggingface.co/datasets/CERN/colliderml-benchmark-results` receives one JSON per submission at `results/<task>/<user>/<sha12>.json`. Pairs with the new client-side `colliderml.tasks.submit(..., model_repo_id=...)` which also lands a `.eval_results/colliderml_<task>.yaml` on the user's HF model repo so scores auto-render on the model card.
+- (0.4.0 — 2026-05-27) - `CERN/ColliderML-Release-1` configs reorganised: per-pileup/per-object split (`{channel}_{pileup}_{tracker_hits,particles,calo_hits,tracks}`) replaces the prior monolithic per-channel layout. Enables event-range-scoped downloads (the `tracking` eval split is now ~700 MB to pull instead of multiple GB).
 - (0.2.0 — 2025-11-07) - Datasets now hosted on HuggingFace Hub for easier access and distribution.
 - (0.2.0 — 2025-11-07) - Support for standard HuggingFace `datasets` library for data loading.
 - (0.2.0 — 2025-11-07) - Migrated from NERSC manifest-based distribution to HuggingFace datasets.
-- (0.2.0 — 2025-11-07) - Data now stored in Parquet format with improved compression and accessibility.
-- (0.1.0 — 2025-09-08) - Initial release of ColliderML dataset with ttbar and ggf physics processes.
 See the full changelog: [Changelog](/changelog).
 :::
 <!-- CHANGELOG:DATASET:END -->

--- a/docs/spaces/event-display.md
+++ b/docs/spaces/event-display.md
@@ -1,6 +1,6 @@
 # Event Display
 
-**Live:** [huggingface.co/spaces/CERN/colliderml-event-display](https://huggingface.co/spaces/CERN/colliderml-event-display)
+**Live:** [huggingface.co/spaces/murnanedaniel/colliderml-event-display](https://huggingface.co/spaces/murnanedaniel/colliderml-event-display)
 **Source:** [`spaces/event-display/`](https://github.com/OpenDataDetector/ColliderML/tree/main/spaces/event-display)
 
 Interactive 3D viewer for single events from the ColliderML datasets.

--- a/docs/spaces/leaderboard.md
+++ b/docs/spaces/leaderboard.md
@@ -1,6 +1,6 @@
 # Leaderboard
 
-**Live:** [huggingface.co/spaces/CERN/colliderml-leaderboard](https://huggingface.co/spaces/CERN/colliderml-leaderboard)
+**Live:** [huggingface.co/spaces/murnanedaniel/colliderml-leaderboard](https://huggingface.co/spaces/murnanedaniel/colliderml-leaderboard)
 **Source:** [`spaces/leaderboard/`](https://github.com/OpenDataDetector/ColliderML/tree/main/spaces/leaderboard)
 
 Public scoreboard for the six benchmark tasks shipped in

--- a/docs/spaces/model-zoo.md
+++ b/docs/spaces/model-zoo.md
@@ -1,6 +1,6 @@
 # Model Zoo
 
-**Live:** [huggingface.co/spaces/CERN/colliderml-model-zoo](https://huggingface.co/spaces/CERN/colliderml-model-zoo)
+**Live:** [huggingface.co/spaces/murnanedaniel/colliderml-model-zoo](https://huggingface.co/spaces/murnanedaniel/colliderml-model-zoo)
 **Source:** [`spaces/model-zoo/`](https://github.com/OpenDataDetector/ColliderML/tree/main/spaces/model-zoo)
 
 A browser for HuggingFace models tagged `colliderml`. Discovery is

--- a/docs/spaces/overview.md
+++ b/docs/spaces/overview.md
@@ -65,7 +65,7 @@ HuggingFace Spaces have a built-in iframe embed:
 
 ```html
 <iframe
-    src="https://huggingface.co/spaces/CERN/colliderml-event-display"
+    src="https://huggingface.co/spaces/murnanedaniel/colliderml-event-display"
     frameborder="0"
     width="850"
     height="450">

--- a/docs/spaces/simulation-form.md
+++ b/docs/spaces/simulation-form.md
@@ -1,6 +1,6 @@
 # Simulation Form
 
-**Live:** [huggingface.co/spaces/CERN/colliderml-simulation](https://huggingface.co/spaces/CERN/colliderml-simulation)
+**Live:** [huggingface.co/spaces/murnanedaniel/colliderml-simulation-form](https://huggingface.co/spaces/murnanedaniel/colliderml-simulation-form)
 **Source:** [`spaces/simulation-form/`](https://github.com/OpenDataDetector/ColliderML/tree/main/spaces/simulation-form)
 
 A graphical front door for the SaaS simulation backend. Two tabs:

--- a/notebooks/tutorial.ipynb
+++ b/notebooks/tutorial.ipynb
@@ -250,7 +250,7 @@
     "scatter \u2192 showered events \u2192 detector simulation \u2192 track reconstruction\n",
     "\u2014 in a single call.\n",
     "\n",
-    "For this chapter we use the `single-muon` preset (fastest, ~5 min).\n"
+    "For this chapter we use the `higgs-portal-quick` preset (~10 min).\n"
    ]
   },
   {
@@ -260,7 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# List the bundled presets. Pick by speed (single-muon fastest, then\n",
+    "# List the bundled presets. Pick by speed (higgs-portal-quick fastest, then\n",
     "# *-quick, then *-dev, then the full *-benchmark workloads).\n",
     "from colliderml.simulate import load_presets\n",
     "\n",
@@ -279,14 +279,14 @@
     "# Actually run the pipeline. Skipped when no container runtime is on\n",
     "# the host \u2014 set HAS_DOCKER at the top of this notebook.\n",
     "if HAS_DOCKER:\n",
-    "    result = colliderml.simulate(preset=\"single-muon\", quiet=True)\n",
+    "    result = colliderml.simulate(preset=\"higgs-portal-quick\", quiet=True)\n",
     "    print(f\"run directory:  {result.run_dir}\")\n",
     "    print(f\"stages run:     {[s.name for s in result.stages]}\")\n",
     "    print(f\"output files:   {sorted(p.name for p in result.run_dir.iterdir())[:6]}\")\n",
     "else:\n",
     "    print(\"Chapter 2 skipped \u2014 no Docker/Podman runtime on this host.\")\n",
     "    print(\"On a laptop or dev box with either installed, this call runs\")\n",
-    "    print(\"the full pipeline (~5 minutes for single-muon) and writes to\")\n",
+    "    print(\"the full pipeline (~10 minutes for higgs-portal-quick) and writes to\")\n",
     "    print(\"./output/runs/0/.\")"
    ]
   },
@@ -588,7 +588,7 @@
     "beats the current best on any metric with `higher_is_better=True`, a\n",
     "credits reward is written to the user's ledger. The leaderboard\n",
     "Space (`spaces/leaderboard/`) polls `/v1/leaderboard/tracking` to\n",
-    "render the table you'd see at <https://huggingface.co/spaces/OpenDataDetector/colliderml-leaderboard>.\n",
+    "render the table you'd see at <https://huggingface.co/spaces/murnanedaniel/colliderml-leaderboard>.\n",
     "\n",
     "**Why an oracle baseline is a useful submission.** It's not a\n",
     "tracking algorithm \u2014 it's a calibration point. Perfect oracle\n",
@@ -615,7 +615,7 @@
     "\n",
     "The ColliderML model zoo is a thin HuggingFace Hub filter: any model\n",
     "on the Hub tagged `colliderml` shows up in\n",
-    "[`spaces/model-zoo`](https://huggingface.co/spaces/OpenDataDetector/colliderml-model-zoo).\n",
+    "[`spaces/model-zoo`](https://huggingface.co/spaces/murnanedaniel/colliderml-model-zoo).\n",
     "There's no backend registry, no approval process \u2014 the `tag` is the\n",
     "contract. Pushing a model is a standard `huggingface_hub.create_repo`\n",
     "+ `upload_folder`.\n",
@@ -739,7 +739,7 @@
     "frames = colliderml.load(\"ttbar_pu0\", tables=[\"tracker_hits\"], max_events=200)\n",
     "\n",
     "# 2. Run the pipeline locally\n",
-    "result = colliderml.simulate(preset=\"single-muon\")\n",
+    "result = colliderml.simulate(preset=\"higgs-portal-quick\")\n",
     "\n",
     "# 3. Submit a remote simulation\n",
     "sub = remote.submit(channel=\"ttbar\", events=10_000, pileup=200)\n",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="colliderml",
-    version="0.4.0rc2",
+    version="0.4.0",
     description="A modern machine learning library for high-energy physics data analysis",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary

Promotes 0.4.0rc2 → 0.4.0 stable + last-mile polish for the docs/tutorial surface.

- **setup.py**: `0.4.0rc2` → `0.4.0`
- **`colliderml/simulate/docker.py`**: `COLLIDERML_PRODUCTION_REF = "staging"` → `"pipeline-v0.1.0"`. Matching tag pushed to colliderml-production master.
- **CHANGELOG**: bump 0.4.0 date to 2026-05-27 + add two `[dataset]`-tagged entries so the docs landing page's auto-synced changelog block surfaces v0.4.0 entries (the sync script only pulls `[dataset]` entries; the previous body was all `[library]`/`[docs]`/`[infra]`, hence the stale 0.2.0 display).
- **Removed `single-muon` preset** + repointed tutorial chapter 2 at `higgs-portal-quick`. Detail: `pipeline.py` routes single_muon through Pythia generation but production's single-muon dataset uses an ACTS particle-gun generator. Reintroducing once that routing is fixed (v0.4.1).
- **HF Space URLs**: docs/tutorial pointed at non-existent `CERN/colliderml-*` and `OpenDataDetector/colliderml-*`; the real Spaces live at `murnanedaniel/colliderml-*` per the sync-spaces.yml HF_USER secret. Pointed everything at the real URLs.

## Test plan

- [x] 162 lib unit tests pass
- [x] Tutorial chapter 4 + 5 verified live: HF dataset receives results JSON, model repo receives eval_results yaml
- [x] `scripts/sync_changelog.mjs` regenerates `docs/index.md` with the new 0.4.0 dataset entries
- [ ] CI green

## Next (after merge)

`gh release create v0.4.0 -R OpenDataDetector/ColliderML --target main --title "v0.4.0"`. `publish-pypi.yml` triggers on `release.published` and publishes to PyPI via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)