### PR TITLE
docs: fix wrong-namespace HF URLs + dataset name casing

### DIFF
--- a/docs/.vitepress/components/DataConfig.vue
+++ b/docs/.vitepress/components/DataConfig.vue
@@ -64,7 +64,7 @@ async function fetchAvailableDatasets() {
   try {
     console.log('[ColliderML] Fetching available configs from HuggingFace...')
     const response = await fetch(
-      'https://huggingface.co/api/datasets/CERN/Colliderml-release-1'
+      'https://huggingface.co/api/datasets/CERN/ColliderML-Release-1'
     )
 
     if (!response.ok) {

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -99,7 +99,7 @@ print(f"ColliderML version: {colliderml.__version__}")
 # Test loading a dataset
 from datasets import load_dataset
 dataset = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_particles",
     split="train"
 )

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -27,7 +27,7 @@ from datasets import load_dataset
 
 # Load the ttbar particles dataset (no pileup)
 dataset = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_particles",
     split="train"
 )
@@ -129,21 +129,21 @@ from datasets import load_dataset
 
 # Load truth-level particles
 particles = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_particles",
     split="train"
 )
 
 # Load tracker hits (detector measurements)
 tracker_hits = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_tracker_hits",
     split="train"
 )
 
 # Load reconstructed tracks
 tracks = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_tracks",
     split="train"
 )
@@ -208,7 +208,7 @@ from datasets import load_dataset
 
 # Load in streaming mode
 dataset = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_particles",
     split="train",
     streaming=True  # Enable streaming
@@ -229,7 +229,7 @@ ColliderML includes multiple physics processes:
 
 ```python
 dataset = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_particles",
     split="train"
 )
@@ -239,7 +239,7 @@ dataset = load_dataset(
 
 ```python
 dataset = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ggf_pu0_particles",
     split="train"
 )
@@ -249,13 +249,13 @@ dataset = load_dataset(
 
 ```python
 dataset = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "dihiggs_pu0_particles",
     split="train"
 )
 ```
 
-Check the [CERN/Colliderml-release-1 dataset page](https://huggingface.co/datasets/CERN/Colliderml-release-1) for a complete list of available configurations.
+Check the [CERN/ColliderML-Release-1 dataset page](https://huggingface.co/datasets/CERN/ColliderML-Release-1) for a complete list of available configurations.
 
 ## Data Inspection Example
 
@@ -267,7 +267,7 @@ import numpy as np
 
 # Load dataset
 dataset = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_particles",
     split="train"
 )
@@ -304,7 +304,7 @@ The datasets library integrates seamlessly with popular ML frameworks:
 from datasets import load_dataset
 
 dataset = load_dataset(
-    "CERN/Colliderml-release-1",
+    "CERN/ColliderML-Release-1",
     "ttbar_pu0_particles",
     split="train"
 )
@@ -341,4 +341,4 @@ If you encounter issues:
 
 - Check the [FAQ](./faq.md)
 - Visit our [GitHub Issues](https://github.com/OpenDataDetector/ColliderML/issues)
-- Consult the [CERN/Colliderml-release-1 dataset page](https://huggingface.co/datasets/CERN/Colliderml-release-1)
+- Consult the [CERN/ColliderML-Release-1 dataset page](https://huggingface.co/datasets/CERN/ColliderML-Release-1)

--- a/docs/guide/tasks.md
+++ b/docs/guide/tasks.md
@@ -145,6 +145,6 @@ at collider trigger latencies.
 
 - Browse the [API reference](../library/tasks.md) for every function signature
 - Read about [remote simulation](./remote-simulation.md) to generate training data
-- Check the live [Leaderboard](https://huggingface.co/spaces/ColliderML/leaderboard)
+- Check the live [Leaderboard](https://huggingface.co/spaces/murnanedaniel/colliderml-leaderboard)
   (deployed from this repo's `spaces/leaderboard/`)
 - Open a PR to add a new task or baseline — contributors earn credits!

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,11 +22,11 @@ model to the zoo.
 - **Load** pre-generated events: `colliderml.load("ttbar_pu0")` — downloads on first call, then caches.
 - **Simulate** new events yourself: [`colliderml.simulate(preset="ttbar-quick")`](/guide/simulation) — runs the full Pythia → Geant4 → ACTS pipeline locally, or submit to the SaaS backend with `remote=True`.
 - **Score** your models against benchmark tasks: [`colliderml.tasks.evaluate(...)`](/guide/tasks) — six built-in tasks covering tracking, jets, anomaly detection, and systems constraints.
-- **Explore** interactively: use the [event display](https://huggingface.co/spaces/ColliderML/event-display) or the [leaderboard](https://huggingface.co/spaces/ColliderML/leaderboard) HuggingFace Spaces.
+- **Explore** interactively: use the [event display](https://huggingface.co/spaces/murnanedaniel/colliderml-event-display) or the [leaderboard](https://huggingface.co/spaces/murnanedaniel/colliderml-leaderboard) HuggingFace Spaces.
 
 ## Get the Data
 
-Download data with the **colliderml** CLI, then load it in Python with Polars. The dataset is also on [HuggingFace](https://huggingface.co/datasets/CERN/Colliderml-release-1) if you prefer the `datasets` library.
+Download data with the **colliderml** CLI, then load it in Python with Polars. The dataset is also on [HuggingFace](https://huggingface.co/datasets/CERN/ColliderML-Release-1) if you prefer the `datasets` library.
 
 ### Quick Start
 

--- a/docs/library/tasks.md
+++ b/docs/library/tasks.md
@@ -247,4 +247,4 @@ installed.
 - [Benchmark Tasks guide](../guide/tasks.md) — conceptual overview
 - [`colliderml.load`](./loading.md) — the low-level loader used by tasks
 - [`colliderml.remote`](./remote.md) — the SaaS client used by `submit()`
-- [Leaderboard Space](https://huggingface.co/spaces/ColliderML/leaderboard) — live rankings
+- [Leaderboard Space](https://huggingface.co/spaces/murnanedaniel/colliderml-leaderboard) — live rankings


### PR DESCRIPTION
Followup polish caught right after v0.4.0 went out. Pure docs/copy fix, no code changes.