### PR TITLE
release: 0.4.1 — simulate kwargs actually take effect + tutorial/widget polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.4.1] - 2026-05-27
+
+### Fixed
+- [library] `colliderml.simulate(events=N, pileup=M, seed=K)` kwargs now actually take effect. They used to be advertised in the user-facing "Running … (N events, pileup=M)" message, then silently dropped — the static per-stage YAML configs won. The fix writes a per-run overlay under `prod_root/.overlays/<run_id>/` with the kwargs applied; each stage reads the overlay instead of the static config.
+- [docs] Landing-page widget (`DataConfig.vue`) now filters channel buttons by the selected pileup level. The widget previously let users pick combinations that don't exist on Hub (e.g. `zee+pu0`, `higgs_portal+pu200`) and copied a CLI command that 404s on download. When the user switches pileup and the current channel isn't available there, the widget falls back to the first valid channel.
+- [docs] Tutorial chapter 2 rewritten to show the three simulate knobs (`channel`, `events`, `pileup`) explicitly instead of hiding them behind a preset name. Defaults to a fast `events=2 pileup=5` demo.
+
 ## [0.4.0] - 2026-05-27
 
 ### Added

--- a/colliderml/simulate/api.py
+++ b/colliderml/simulate/api.py
@@ -74,6 +74,73 @@ class SimulationResult:
         )
 
 
+def _apply_runtime_overrides(
+    manifest: list,
+    *,
+    prod_root: Path,
+    run_id: str,
+    events: int,
+    pileup: int,
+    seed: int,
+) -> list:
+    """Write per-run YAML overlays so the caller's kwargs actually take effect.
+
+    Each stage in the manifest points at a static YAML config under
+    ``prod_root/configs_development/docker_test/<channel>/``. Those YAMLs
+    have hardcoded ``events``/``pileup`` defaults (e.g. ``events: 10``).
+    Without this overlay step, the caller's ``simulate(events=2, pileup=5)``
+    kwargs get silently dropped — the YAML wins.
+
+    This helper:
+      1. Reads each stage's original YAML.
+      2. Overrides the ``events`` / ``pileup`` / ``seed`` keys with the
+         caller's values (only when the key already exists in the YAML —
+         we don't add fields that the stage script doesn't know about).
+      3. Writes the modified YAML to
+         ``prod_root/.overlays/<run_id>/<stage>_<original_basename>``.
+      4. Returns a manifest with each entry's ``config_path`` rewritten
+         to point at the overlay.
+
+    The overlay path stays under ``prod_root`` so the existing
+    ``--config /workspace/<config_path>`` in ``run_stage`` keeps working
+    unchanged. ``run_id`` namespacing lets concurrent runs coexist.
+    """
+    import yaml
+
+    overlay_root = prod_root / ".overlays" / run_id
+    overlay_root.mkdir(parents=True, exist_ok=True)
+
+    OVERRIDE_KEYS = {"events": events, "pileup": pileup, "seed": seed}
+
+    new_manifest = []
+    for stage in manifest:
+        orig_rel = stage["config_path"]
+        orig_path = prod_root / orig_rel
+        with open(orig_path) as f:
+            cfg = yaml.safe_load(f) or {}
+
+        # Only override keys the stage's config already declares — don't
+        # inject new fields. e.g. ttbar's madgraph_init_config.yaml has
+        # no `events` key (MadGraph init isn't event-count-driven), so we
+        # leave it alone.
+        for key, value in OVERRIDE_KEYS.items():
+            if key in cfg and value is not None:
+                cfg[key] = value
+
+        orig_basename = Path(orig_rel).name
+        overlay_rel = Path(".overlays") / run_id / f"{stage['stage']}__{orig_basename}"
+        overlay_path = prod_root / overlay_rel
+        overlay_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(overlay_path, "w") as f:
+            yaml.safe_dump(cfg, f, sort_keys=False)
+
+        new_stage = dict(stage)
+        new_stage["config_path"] = str(overlay_rel)
+        new_manifest.append(new_stage)
+
+    return new_manifest
+
+
 def _default_output_dir(channel: str, pileup: int, events: int) -> Path:
     """Compute a sensible default output directory if the caller didn't give one."""
     return (Path.cwd() / "colliderml_output" / f"{channel}_pu{pileup}_{events}evt").resolve()
@@ -234,6 +301,20 @@ def simulate(
             f"No stages were generated for channel '{resolved_channel}'. "
             f"Is the colliderml-production clone at {prod} up to date?"
         )
+
+    # Apply the caller's events / pileup / seed kwargs by writing per-run
+    # overlay YAMLs under prod_root/.overlays/<run_id>/. Each stage script
+    # reads its config from disk and uses whatever value is in the YAML,
+    # so without this overlay step the static configs win and the
+    # caller's kwargs get silently dropped after we've printed them back.
+    manifest = _apply_runtime_overrides(
+        manifest,
+        prod_root=prod,
+        run_id=run_id,
+        events=resolved_events,
+        pileup=resolved_pileup,
+        seed=seed,
+    )
 
     def _on_start(i: int, total: int, name: str) -> None:
         if not quiet:

--- a/docs/.vitepress/components/DataConfig.vue
+++ b/docs/.vitepress/components/DataConfig.vue
@@ -14,8 +14,9 @@ const expanded = ref({
 })
 
 // Available data from HuggingFace
-const channelTypes = ref([])
+const channelTypes = ref([])      // every (channel) we've ever seen — filtered for display
 const pileupTypes = ref([])
+const channelsByPileup = ref({})  // { "pu0": Set<channel>, "pu200": Set<channel> }
 const loading = ref(true)
 
 // Fixed object types for all ColliderML datasets (sizes loaded dynamically)
@@ -90,30 +91,34 @@ async function fetchAvailableDatasets() {
       throw new Error('No configs found in dataset')
     }
 
-    // Parse configs to extract processes and pileup levels
+    // Parse configs into a per-pileup channel map so the channel buttons
+    // can be filtered when the user changes the pileup level. The dataset
+    // doesn't have every (channel × pileup) combination — e.g. `zee` is
+    // PU=200 only, `higgs_portal` is PU=0 only — so showing them all at
+    // once produces commands that 404 on download.
     const processes = new Set()
     const pileups = new Set()
+    const byPileup = {}
 
     configs.forEach(config => {
       const parts = config.split('_')
-      if (parts.length >= 3) {
-        // Handle multi-word processes like "dihiggs"
-        const objectTypes = ['particles', 'tracker', 'calo', 'tracks']
-        let pileupIdx = parts.findIndex(p => p.startsWith('pu'))
-
-        if (pileupIdx > 0) {
-          const process = parts.slice(0, pileupIdx).join('_')
-          const pileup = parts[pileupIdx]
-          processes.add(process)
-          pileups.add(pileup)
-        }
+      const pileupIdx = parts.findIndex(p => p.startsWith('pu'))
+      if (pileupIdx > 0) {
+        const process = parts.slice(0, pileupIdx).join('_')  // handles "higgs_portal" etc.
+        const pileup = parts[pileupIdx]
+        processes.add(process)
+        pileups.add(pileup)
+        if (!byPileup[pileup]) byPileup[pileup] = new Set()
+        byPileup[pileup].add(process)
       }
     })
 
     console.log('[ColliderML] Found processes:', Array.from(processes))
     console.log('[ColliderML] Found pileups:', Array.from(pileups))
+    console.log('[ColliderML] Channels per pileup:',
+      Object.fromEntries(Object.entries(byPileup).map(([p, s]) => [p, Array.from(s)])))
 
-    channelTypes.value = Array.from(processes).map(ch => ({
+    channelTypes.value = Array.from(processes).sort().map(ch => ({
       id: ch,
       label: ch,
       available: true
@@ -124,6 +129,11 @@ async function fetchAvailableDatasets() {
       label: pu === 'pu0' ? 'No Pileup (pu0)' : `Pileup ${pu.replace('pu', '')}`,
       available: true
     }))
+
+    // Store the per-pileup channel map (Sets serialised as plain objects).
+    channelsByPileup.value = Object.fromEntries(
+      Object.entries(byPileup).map(([p, s]) => [p, Array.from(s)])
+    )
 
     loading.value = false
 
@@ -148,16 +158,40 @@ onMounted(async () => {
   await fetchAvailableDatasets()
 })
 
+// Channels that actually exist at the currently-selected pileup level.
+// This is what the template iterates — channel buttons appear/disappear
+// as the user switches PU=0 vs PU=200.
+const availableChannelsForPileup = computed(() => {
+  const pileup = selections.value.pileup
+  const available = new Set(channelsByPileup.value[pileup] || [])
+  return channelTypes.value.filter(ch => available.has(ch.id))
+})
+
 // Check if current selection is available
 const isDatasetAvailable = computed(() => {
   const channel = selections.value.channels[0]
   const pileup = selections.value.pileup
 
-  const hasChannel = channelTypes.value.some(ch => ch.id === channel)
+  const hasChannel = availableChannelsForPileup.value.some(ch => ch.id === channel)
   const hasPileup = pileupTypes.value.some(pu => pu.id === pileup)
 
   return hasChannel && hasPileup
 })
+
+// When the user switches pileup level, the current channel may not exist
+// at the new pileup (e.g. switching from pu0 to pu200 while `higgs_portal`
+// is selected). Auto-fall-back to the first available channel.
+const onPileupChange = (newPileup) => {
+  selections.value.pileup = newPileup
+  const valid = new Set(channelsByPileup.value[newPileup] || [])
+  const current = selections.value.channels[0]
+  if (!valid.has(current)) {
+    const fallback = Array.from(valid).sort()[0]
+    if (fallback) {
+      selections.value.channels = [fallback]
+    }
+  }
+}
 
 // Size estimation (MB per 1000 events per object)
 const estimatedSizeMB = computed(() => {
@@ -311,7 +345,7 @@ const formatEventCount = (count) => {
               :key="pu.id"
               class="select-button"
               :class="{ selected: selections.pileup === pu.id }"
-              @click="selections.pileup = pu.id"
+              @click="onPileupChange(pu.id)"
             >
               {{ pu.label }}
             </button>
@@ -321,9 +355,9 @@ const formatEventCount = (count) => {
         <!-- Channels Card -->
         <div class="config-card">
           <div class="card-header">
-            <h4>Physics Process</h4>
+            <h4>Physics Process <span class="muted-note">(available at {{ selections.pileup }})</span></h4>
             <button
-              v-if="channelTypes.length > 3"
+              v-if="availableChannelsForPileup.length > 3"
               class="expand-button"
               :class="{ expanded: expanded.channels }"
               @click="toggleExpand('channels')"
@@ -333,7 +367,7 @@ const formatEventCount = (count) => {
           </div>
           <div class="button-grid">
             <button
-              v-for="channel in expanded.channels ? channelTypes : channelTypes.slice(0, 3)"
+              v-for="channel in expanded.channels ? availableChannelsForPileup : availableChannelsForPileup.slice(0, 3)"
               :key="channel.id"
               class="select-button"
               :class="{ selected: isSelected('channels', channel.id) }"
@@ -516,6 +550,13 @@ h4 {
 
 .card-header h4 {
   margin: 0;
+}
+
+.muted-note {
+  color: var(--vp-c-text-3);
+  font-size: 0.85em;
+  font-weight: normal;
+  margin-left: 4px;
 }
 
 .expand-button {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.4.1] - 2026-05-27
+
+### Fixed
+- [library] `colliderml.simulate(events=N, pileup=M, seed=K)` kwargs now actually take effect. They used to be advertised in the user-facing "Running … (N events, pileup=M)" message, then silently dropped — the static per-stage YAML configs won. The fix writes a per-run overlay under `prod_root/.overlays/<run_id>/` with the kwargs applied; each stage reads the overlay instead of the static config.
+- [docs] Landing-page widget (`DataConfig.vue`) now filters channel buttons by the selected pileup level. The widget previously let users pick combinations that don't exist on Hub (e.g. `zee+pu0`, `higgs_portal+pu200`) and copied a CLI command that 404s on download. When the user switches pileup and the current channel isn't available there, the widget falls back to the first valid channel.
+- [docs] Tutorial chapter 2 rewritten to show the three simulate knobs (`channel`, `events`, `pileup`) explicitly instead of hiding them behind a preset name. Defaults to a fast `events=2 pileup=5` demo.
+
 ## [0.4.0] - 2026-05-27
 
 ### Added

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -113,20 +113,42 @@ that bundles MadGraph, Pythia, Geant4 + ddsim, and ACTS. The
 hard-scatter generation → parton shower → detector simulation →
 track reconstruction — in a single call.
 
-For this chapter we use the `higgs-portal-quick` preset — ten
-Higgs-portal events with low pileup, ~10 minutes on a modern laptop.
+Three knobs control what you actually generate:
+
+- **`channel`** — the physics process (`ttbar`, `higgs_portal`, …; see
+  `colliderml.simulate.load_presets()` for the wired-up channels).
+- **`events`** — how many hard-scatter events. Each one costs ~10–30 s
+  of Geant4 stepping on a typical laptop CPU.
+- **`pileup`** — average soft pp interactions overlaid per hard scatter.
+  `0` is fastest (signal only); LHC reality is ~200. Cost scales
+  roughly linearly with pileup.
+
+For this chapter we set the three knobs explicitly to tiny values so
+the whole pipeline finishes in ~2 minutes. Bump them once you have
+time:
 
 ```python
-from colliderml.simulate import load_presets
 import colliderml
 
-for name, cfg in load_presets().items():
-    print(f"  {name:24}  channel={cfg['channel']:14} events={cfg['events']:>4} pileup={cfg['pileup']}")
+CHANNEL = "higgs_portal"
+EVENTS = 2
+PILEUP = 5
 
-result = colliderml.simulate(preset="higgs-portal-quick", quiet=True)
+result = colliderml.simulate(
+    channel=CHANNEL,
+    events=EVENTS,
+    pileup=PILEUP,
+    quiet=True,
+)
 print("run directory:", result.run_dir)
 print("stages run:   ", [s.name for s in result.stages])
 ```
+
+Presets are also available as named bundles of the same three knobs —
+`colliderml.simulate(preset="ttbar-quick")` is equivalent to setting
+`channel="ttbar", events=10, pileup=0`. List them with
+`colliderml.simulate.load_presets()`. The tutorial uses explicit knobs
+so the dimensions stay visible.
 
 ### What just happened
 
@@ -470,7 +492,7 @@ from huggingface_hub import create_repo, upload_folder
 frames = colliderml.load("ttbar_pu0", tables=["tracker_hits"], max_events=200)
 
 # 2. Run the pipeline locally
-result = colliderml.simulate(preset="higgs-portal-quick")
+result = colliderml.simulate(channel="higgs_portal", events=2, pileup=5)
 
 # 3. Submit a remote simulation
 sub = remote.submit(channel="ttbar", events=10_000, pileup=200)

--- a/notebooks/tutorial.ipynb
+++ b/notebooks/tutorial.ipynb
@@ -240,17 +240,7 @@
    "id": "223b30bd",
    "metadata": {},
    "source": [
-    "\n",
-    "## Chapter 2 \u2014 Run the pipeline yourself: local simulation\n",
-    "\n",
-    "ColliderML ships a container\n",
-    "(`ghcr.io/opendatadetector/sw:0.2.2_linux-ubuntu24.04_gcc-13.3.0`)\n",
-    "that bundles MadGraph, Pythia, Geant4+ddsim, and ACTS. The\n",
-    "`colliderml.simulate` subpackage drives the full pipeline \u2014 hard\n",
-    "scatter \u2192 showered events \u2192 detector simulation \u2192 track reconstruction\n",
-    "\u2014 in a single call.\n",
-    "\n",
-    "For this chapter we use the `higgs-portal-quick` preset (~10 min).\n"
+    "\n## Chapter 2 \u2014 Run the pipeline yourself: local simulation\n\nColliderML ships a container\n(`ghcr.io/opendatadetector/sw:0.2.2_linux-ubuntu24.04_gcc-13.3.0`)\nthat bundles MadGraph, Pythia, Geant4+ddsim, and ACTS. The\n`colliderml.simulate` subpackage drives the full pipeline \u2014 hard\nscatter \u2192 showered events \u2192 detector simulation \u2192 track reconstruction\n\u2014 in a single call.\n\nThree knobs control what you actually generate:\n\n- **`channel`** \u2014 the physics process (`ttbar`, `higgs_portal`, \u2026; see\n  `colliderml.simulate.load_presets()` for what's wired up).\n- **`events`** \u2014 how many hard-scatter events. Each one costs ~10\u201330 s\n  of Geant4 stepping on a typical laptop CPU.\n- **`pileup`** \u2014 average number of soft pp interactions overlaid per\n  hard scatter. `0` is fastest (just the signal); LHC reality is\n  ~200. Pileup scales the per-event Geant4 cost roughly linearly.\n\nFor this chapter we run a tiny demo (2 events, pileup 5) so you can\nwatch the whole pipeline in ~2 minutes. Bump the knobs at the bottom\nof the cell once you have time to spare.\n"
    ]
   },
   {
@@ -260,13 +250,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# List the bundled presets. Pick by speed (higgs-portal-quick fastest, then\n",
-    "# *-quick, then *-dev, then the full *-benchmark workloads).\n",
-    "from colliderml.simulate import load_presets\n",
-    "\n",
-    "presets = load_presets()\n",
-    "for name, cfg in presets.items():\n",
-    "    print(f\"  {name:24}  channel={cfg.channel:14} events={cfg.events:>4} pileup={cfg.pileup}\")"
+    "# A preset is just a named bundle of (channel, events, pileup). Listed\n# here so you can see what's wired up out of the box \u2014 in the next cell\n# we'll set the three knobs directly instead, so the dimensions are visible.\nfrom colliderml.simulate import load_presets\n\npresets = load_presets()\nfor name, cfg in presets.items():\n    print(f\"  {name:24}  channel={cfg.channel:14} events={cfg.events:>4} pileup={cfg.pileup}\")\n"
    ]
   },
   {
@@ -276,18 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Actually run the pipeline. Skipped when no container runtime is on\n",
-    "# the host \u2014 set HAS_DOCKER at the top of this notebook.\n",
-    "if HAS_DOCKER:\n",
-    "    result = colliderml.simulate(preset=\"higgs-portal-quick\", quiet=True)\n",
-    "    print(f\"run directory:  {result.run_dir}\")\n",
-    "    print(f\"stages run:     {[s.name for s in result.stages]}\")\n",
-    "    print(f\"output files:   {sorted(p.name for p in result.run_dir.iterdir())[:6]}\")\n",
-    "else:\n",
-    "    print(\"Chapter 2 skipped \u2014 no Docker/Podman runtime on this host.\")\n",
-    "    print(\"On a laptop or dev box with either installed, this call runs\")\n",
-    "    print(\"the full pipeline (~10 minutes for higgs-portal-quick) and writes to\")\n",
-    "    print(\"./output/runs/0/.\")"
+    "# Run the pipeline. Skipped when no container runtime is on the host \u2014\n# set HAS_DOCKER at the top of this notebook.\n#\n# The three knobs are visible at the top of the call. Defaults are tiny\n# (2 events \u00d7 pileup 5, ~2 min on a laptop) so this cell finishes while\n# you're reading it. Try EVENTS=10, PILEUP=10 if you have a few more\n# minutes; EVENTS=1000, PILEUP=200 for benchmark-scale (an hour+).\nCHANNEL = \"higgs_portal\"\nEVENTS = 2\nPILEUP = 5\n\nif HAS_DOCKER:\n    print(f\"Generating {EVENTS} events of {CHANNEL} at pileup {PILEUP} \u2026\")\n    result = colliderml.simulate(\n        channel=CHANNEL,\n        events=EVENTS,\n        pileup=PILEUP,\n        quiet=True,\n    )\n    print(f\"run directory:  {result.run_dir}\")\n    print(f\"stages run:     {[s.name for s in result.stages]}\")\n    print(f\"output files:   {sorted(p.name for p in result.run_dir.iterdir())[:6]}\")\nelse:\n    print(\"Chapter 2 skipped \u2014 no Docker/Podman runtime on this host.\")\n    print(\"On a laptop or dev box with either installed, this call runs\")\n    print(f\"the full pipeline (~2 min for {EVENTS} events \u00d7 pileup {PILEUP})\")\n    print(\"and writes to ./output/runs/0/.\")\n"
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="colliderml",
-    version="0.4.0",
+    version="0.4.1",
     description="A modern machine learning library for high-energy physics data analysis",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_simulate_api.py
+++ b/tests/test_simulate_api.py
@@ -64,6 +64,18 @@ def _install_simulate_stubs(
     def fake_generate_stage_manifest(channel: str, *, prod_root: Path) -> List[Dict[str, str]]:
         captured["manifest_channel"] = channel
         captured["manifest_prod_root"] = prod_root
+        # Materialise stub YAML files alongside the manifest entries so the
+        # runtime-overrides overlay step (which reads each stage's YAML to
+        # apply events/pileup/seed kwargs) has something to load.
+        import yaml as _yaml
+        cfg_dir = prod_root / f"configs_development/docker_test/{channel}"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "pythia_config.yaml").write_text(
+            _yaml.safe_dump({"events": 10, "pileup": 10, "seed": 42})
+        )
+        (cfg_dir / "simulation_config.yaml").write_text(
+            _yaml.safe_dump({"events": 10, "pileup": 10, "seed": 42})
+        )
         return [
             {
                 "name": "Pythia Generation",
@@ -179,3 +191,117 @@ def test_simulation_result_list_files_includes_stage_output(
     )
     files = result.list_files()
     assert any(fp.name == "merged_events.hepmc3" for fp in files)
+
+
+# ---------------------------------------------------------------------------
+# Runtime override overlays (events / pileup / seed kwargs actually take effect)
+# ---------------------------------------------------------------------------
+class TestRuntimeOverrides:
+    """``simulate(events=N, pileup=M)`` must propagate into the per-stage
+    YAML configs that the container reads. Without the overlay step the
+    static YAMLs win and the caller's kwargs get silently dropped after
+    the user-facing 'Running … (N events, pileup=M)' message."""
+
+    def test_overlay_overrides_events_pileup_seed(self, tmp_path: Path) -> None:
+        import yaml as _yaml
+        from colliderml.simulate.api import _apply_runtime_overrides
+
+        # Fake prod_root with one stage config containing all three keys.
+        cfg_dir = tmp_path / "configs_development/docker_test/higgs_portal"
+        cfg_dir.mkdir(parents=True)
+        cfg_path = cfg_dir / "pythia_config.yaml"
+        cfg_path.write_text(_yaml.safe_dump({
+            "events": 10, "pileup": 10, "seed": 42, "channel": "higgs_portal",
+        }))
+
+        manifest = [{
+            "name": "Pythia Generation",
+            "stage": "pythia_generation",
+            "script": "simulation/pythia_gen.py",
+            "config_path": "configs_development/docker_test/higgs_portal/pythia_config.yaml",
+        }]
+
+        new_manifest = _apply_runtime_overrides(
+            manifest, prod_root=tmp_path, run_id="0",
+            events=2, pileup=5, seed=99,
+        )
+        # config_path was rewritten to the overlay
+        assert new_manifest[0]["config_path"].startswith(".overlays/0/")
+        overlay = tmp_path / new_manifest[0]["config_path"]
+        assert overlay.exists()
+
+        # Loaded values reflect the kwargs
+        loaded = _yaml.safe_load(overlay.read_text())
+        assert loaded["events"] == 2
+        assert loaded["pileup"] == 5
+        assert loaded["seed"] == 99
+
+    def test_overlay_preserves_unrelated_keys(self, tmp_path: Path) -> None:
+        import yaml as _yaml
+        from colliderml.simulate.api import _apply_runtime_overrides
+
+        cfg_dir = tmp_path / "configs_development/docker_test/higgs_portal"
+        cfg_dir.mkdir(parents=True)
+        (cfg_dir / "pythia_config.yaml").write_text(_yaml.safe_dump({
+            "events": 10,
+            "pythia_settings": ["Higgs:useBSM = on", "35:m0 = 125.0"],
+            "vertex_sigma_xy": 0.0125,
+        }))
+
+        manifest = [{"name": "P", "stage": "pythia_generation",
+                     "script": "s", "config_path": "configs_development/docker_test/higgs_portal/pythia_config.yaml"}]
+        new_manifest = _apply_runtime_overrides(
+            manifest, prod_root=tmp_path, run_id="0",
+            events=2, pileup=5, seed=42,
+        )
+        loaded = _yaml.safe_load((tmp_path / new_manifest[0]["config_path"]).read_text())
+        assert loaded["events"] == 2
+        # Hand-crafted Pythia knobs survive
+        assert loaded["pythia_settings"] == ["Higgs:useBSM = on", "35:m0 = 125.0"]
+        assert loaded["vertex_sigma_xy"] == 0.0125
+
+    def test_overlay_skips_missing_keys(self, tmp_path: Path) -> None:
+        """A stage's YAML without an ``events`` key shouldn't gain one —
+        e.g. madgraph_init_config doesn't take an event count, we shouldn't
+        forge it into the config."""
+        import yaml as _yaml
+        from colliderml.simulate.api import _apply_runtime_overrides
+
+        cfg_dir = tmp_path / "configs_development/docker_test/ttbar"
+        cfg_dir.mkdir(parents=True)
+        (cfg_dir / "madgraph_init_config.yaml").write_text(_yaml.safe_dump({
+            "process": "p p > t t~",
+            "order": "NLO",
+            # no `events`, no `pileup`
+        }))
+        manifest = [{"name": "MG init", "stage": "madgraph_init",
+                     "script": "s", "config_path": "configs_development/docker_test/ttbar/madgraph_init_config.yaml"}]
+        new_manifest = _apply_runtime_overrides(
+            manifest, prod_root=tmp_path, run_id="0",
+            events=2, pileup=5, seed=42,
+        )
+        loaded = _yaml.safe_load((tmp_path / new_manifest[0]["config_path"]).read_text())
+        assert "events" not in loaded
+        assert "pileup" not in loaded
+        # Stage-specific keys preserved
+        assert loaded["process"] == "p p > t t~"
+
+    def test_overlay_per_run_id_namespacing(self, tmp_path: Path) -> None:
+        import yaml as _yaml
+        from colliderml.simulate.api import _apply_runtime_overrides
+
+        cfg = tmp_path / "configs_development/docker_test/higgs_portal/pythia_config.yaml"
+        cfg.parent.mkdir(parents=True)
+        cfg.write_text(_yaml.safe_dump({"events": 10, "pileup": 10}))
+        manifest = [{"name": "P", "stage": "pythia_generation",
+                     "script": "s", "config_path": "configs_development/docker_test/higgs_portal/pythia_config.yaml"}]
+
+        _apply_runtime_overrides(manifest, prod_root=tmp_path, run_id="alpha",
+                                 events=2, pileup=5, seed=42)
+        _apply_runtime_overrides(manifest, prod_root=tmp_path, run_id="beta",
+                                 events=99, pileup=200, seed=42)
+
+        alpha = _yaml.safe_load((tmp_path / ".overlays/alpha/pythia_generation__pythia_config.yaml").read_text())
+        beta = _yaml.safe_load((tmp_path / ".overlays/beta/pythia_generation__pythia_config.yaml").read_text())
+        assert alpha["events"] == 2 and alpha["pileup"] == 5
+        assert beta["events"] == 99 and beta["pileup"] == 200


### PR DESCRIPTION
## Summary

Two real bugs found while verifying chapter 2 of the tutorial end-to-end on murnanelabs, plus the tutorial rewrite that motivated the search.

- **simulate(events=, pileup=, seed=) kwargs silently dropped**: the API advertised them, printed them back to the user, then ignored them — the static YAMLs in `configs_development/docker_test/<channel>/` won. Caller asking for `events=2 pileup=5` actually got `10x10`. Fixed via per-run overlay YAMLs at `prod_root/.overlays/<run_id>/`.
- **Tutorial chapter 2 + landing-page widget rewrites** (already on this branch from prior commit): notebook now uses explicit `channel/events/pileup` instead of opaque preset name; widget filters channels by the selected pileup so `zee+pu0` / `higgs_portal+pu200` are no longer presented as valid combos.

Production-repo pipeline-v0.1.0 also force-moved twice during this window for two parquet-stage fixes (polars+huggingface_hub deps, convert_all arg parser). Both squash-merged to master and the tag points at the latest fix.

## Test plan

- [x] 4 new `TestRuntimeOverrides` cases in `tests/test_simulate_api.py`
- [x] 166 fast tests pass on the full suite
- [x] Manual: `simulate(channel="higgs_portal", events=2, pileup=5)` against the patched local cache produces the overlay YAML with the right values
- [ ] CI green
- [ ] Tag v0.4.1 after merge → publish-pypi.yml auto-publishes

## Known issue (not in this release)

`convert_all.py` runs to completion exit-0 but produces no parquets — it scans for "runs" in a directory layout that doesn't match what stages 1-3 write. Stages 1-3 (Pythia, Geant4, ACTS reco) do produce the real outputs (ROOT + HepMC3). Filing as a v0.4.2 follow-up; doesn't block the conference demo, which already shows what those stages produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)