### PR TITLE
docs(copilot): fix Anthropic 400 on multi-turn (strip null block fields)

### DIFF
--- a/docs/.vitepress/components/Copilot.vue
+++ b/docs/.vitepress/components/Copilot.vue
@@ -141,7 +141,14 @@ async function runLoop() {
       apiMessages.value.push({ role: 'assistant', content: [{ type: 'text', text: `⚠ ${msg}` }] })
       return
     }
-    const blocks = data.content || []
+    // Keep only the fields valid for each block type. The backend returns blocks
+    // with all fields populated (text blocks carry id/name/input = null); echoing
+    // those back into the next turn makes Anthropic reject "extra inputs".
+    const blocks = (data.content || []).map((b: any) => {
+      if (b.type === 'tool_use') return { type: 'tool_use', id: b.id, name: b.name, input: b.input ?? {} }
+      if (b.type === 'text') return { type: 'text', text: b.text ?? '' }
+      return b
+    })
     apiMessages.value.push({ role: 'assistant', content: blocks })
 
     const toolUses = blocks.filter((b: any) => b.type === 'tool_use')


### PR DESCRIPTION
Fixes the copilot error after the first message (e.g. ttbar → then ask for pu200 zmumu): `messages.N.content.0.text.id: Extra inputs are not permitted`.

The backend returns blocks with all fields populated (text blocks carry `id/name/input = null`); echoing them back made Anthropic reject the next turn. Now we keep only the valid fields per block type before storing the assistant message. Verified against the live backend (dirty history → 400, cleaned → 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)