### PR TITLE
docs: add hep-viz citation (BibTeX) + homepage credit

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ Drag to orbit, scroll to zoom.
 
 <EventDisplay />
 
+Event display powered by [hep-viz](https://github.com/FinnbarWilson/hep-viz)
+(Wilson & Facini, UCL; [doi:10.5281/zenodo.18387794](https://doi.org/10.5281/zenodo.18387794)).
 See more on the [detector & events page](/visualize).
 
 </AboutData>

--- a/docs/visualize.md
+++ b/docs/visualize.md
@@ -42,6 +42,22 @@ client-side over pre-exported events — no backend required. To explore the who
 dataset interactively, `pip install hep-viz` and run `hep-viz view <data-dir>`.
 :::
 
+## Citing hep-viz
+
+If you use the event display in your work, please cite hep-viz:
+
+```bibtex
+@software{hepviz,
+  author    = {Wilson, Finnbar and Facini, Gabriel},
+  title     = {hep-viz},
+  version   = {0.1.5},
+  publisher = {Zenodo},
+  year      = {2026},
+  doi       = {10.5281/zenodo.18387794},
+  url       = {https://doi.org/10.5281/zenodo.18387794}
+}
+```
+
 ::: info Credits
 Detector renders: the [Open Data Detector](https://github.com/OpenDataDetector/OpenDataDetector) project.
 :::


### PR DESCRIPTION
Adds a formal BibTeX citation for hep-viz on /visualize and an inline credit under the homepage event-display embed. 🤖 Generated with [Claude Code](https://claude.com/claude-code)