### PR TITLE
tests: pipeline-health suite (per-stage + e2e) — red dashboard = worklist

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -1,0 +1,123 @@
+name: Pipeline Health
+
+# Runs the per-stage + end-to-end pipeline tests (tests/pipeline) as a
+# NON-BLOCKING red/green dashboard — red == the worklist, not a merge gate.
+# (The gating tests.yml excludes `-m pipeline`.)
+#
+#   hermetic job (PRs + nightly): stands up the backend via docker-compose
+#     (mock-SFAPI, ALLOW_TEST_TOKEN) and runs the hermetic + e2e tests.
+#   live job (nightly + manual): hits the deployed backend to catch drift
+#     (e.g. the /v1/leaderboard 500). No secrets needed.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  hermetic:
+    runs-on: ubuntu-latest
+    continue-on-error: true          # dashboard, not a gate
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check out the backend (for docker-compose)
+        uses: actions/checkout@v4
+        with:
+          repository: OpenDataDetector/colliderml-production
+          ref: staging
+          path: colliderml-production
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install library
+        run: pip install -e ".[tasks,remote,dev]"
+
+      - name: Stand up backend (mock-SFAPI, test-auth seam)
+        working-directory: colliderml-production/backend
+        env:
+          ADMIN_TOKEN: dev-admin-token
+          ALLOW_TEST_TOKEN: "1"
+          AUTH_TEST_USER: ci-pipeline
+        run: docker compose up -d --build
+
+      - name: Wait for backend health
+        run: |
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:8000/healthz && break || sleep 2
+          done
+          curl -sf http://localhost:8000/healthz
+
+      - name: Run hermetic pipeline + e2e
+        continue-on-error: true
+        env:
+          COLLIDERML_BACKEND: http://localhost:8000
+          ADMIN_TOKEN: dev-admin-token
+          HF_TOKEN: ci-dummy-token     # accepted by the backend's ALLOW_TEST_TOKEN seam
+        run: |
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -v -p no:cacheprovider \
+            -m "pipeline and not live and not sim" tests/pipeline \
+            --junitxml=pipeline-hermetic.xml
+
+      - name: Publish hermetic dashboard
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Pipeline Health (hermetic)
+          path: pipeline-hermetic.xml
+          reporter: java-junit
+          fail-on-error: false
+
+      - name: Backend logs
+        if: always()
+        working-directory: colliderml-production/backend
+        run: docker compose logs --no-color > backend.log 2>&1; docker compose down -v || true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-hermetic
+          path: |
+            pipeline-hermetic.xml
+            colliderml-production/backend/backend.log
+
+  live:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'   # drift lane: nightly / manual only
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install library
+        run: pip install -e ".[tasks,remote,dev]"
+      - name: Run live drift lane
+        continue-on-error: true
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}    # auth'd live tests skip if empty
+        run: |
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -v -p no:cacheprovider \
+            -m "live" tests/pipeline --junitxml=pipeline-live.xml
+      - name: Publish live dashboard
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Pipeline Health (live)
+          path: pipeline-live.xml
+          reporter: java-junit
+          fail-on-error: false
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-live
+          path: pipeline-live.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     
     - name: Run tests
       run: |
-        PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -v -p pytest_cov -m "not slow and not integration" --cov=colliderml --cov-report=xml --cov-report=term-missing
+        PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -v -p pytest_cov -m "not slow and not integration and not pipeline" --cov=colliderml --cov-report=xml --cov-report=term-missing
 
     - name: Download benchmark (warn-only)
       run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,12 @@
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests that require network access and real data (deselect with '-m "not integration"')
+    pipeline: pipeline-health stage test (one module per core-loop stage)
+    e2e: single end-to-end chain across all stages
+    live: requires the deployed backend ($COLLIDERML_BACKEND -> colliderml-backend.onrender.com)
+    hermetic: requires a CI-stood-up backend at $COLLIDERML_BACKEND (docker-compose, no secrets)
+    sim: requires a local Docker/Podman runtime + the ODD image (~10GB)
+    needs_hf_token: requires a real HF bearer token (skips cleanly without $HF_TOKEN)
 
 # Note: If you have ROS pytest plugins installed that cause conflicts,
 # run pytest with: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest ...

--- a/tests/pipeline/_http.py
+++ b/tests/pipeline/_http.py
@@ -1,0 +1,59 @@
+"""Tiny stdlib HTTP helpers for the pipeline suite (no `requests` dependency)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Dict, Optional
+
+LIVE_BACKEND_URL = os.environ.get(
+    "COLLIDERML_LIVE_BACKEND", "https://colliderml-backend.onrender.com"
+).rstrip("/")
+
+
+def _maybe_json(body: str):
+    try:
+        return json.loads(body)
+    except (ValueError, TypeError):
+        return body
+
+
+def http_get(url: str, *, timeout: float = 15.0, headers: Optional[Dict[str, str]] = None):
+    """GET a URL; return (status_code, parsed_json_or_text)."""
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, _maybe_json(resp.read().decode("utf-8", "replace"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "replace") if e.fp else ""
+        return e.code, _maybe_json(body)
+
+
+def http_post(url: str, *, json_body=None, timeout: float = 30.0, headers: Optional[Dict[str, str]] = None):
+    """POST JSON to a URL; return (status_code, parsed_json_or_text)."""
+    data = json.dumps(json_body or {}).encode("utf-8")
+    hdrs = {"Content-Type": "application/json", **(headers or {})}
+    req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, _maybe_json(resp.read().decode("utf-8", "replace"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "replace") if e.fp else ""
+        return e.code, _maybe_json(body)
+
+
+def wait_for_health(base_url: str, *, deadline_s: float = 90.0) -> bool:
+    """Poll ``{base_url}/healthz`` until 200 or the deadline (cold-start safe)."""
+    end = time.time() + deadline_s
+    while time.time() < end:
+        try:
+            status, _ = http_get(f"{base_url}/healthz", timeout=10.0)
+            if status == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(3.0)
+    return False

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -1,0 +1,163 @@
+"""Shared fixtures for the pipeline-health suite.
+
+Reuses the existing mock harnesses (``_FakeRequests`` from
+``tests/test_remote_client.py``, the ``stub_loader`` pattern from
+``tests/test_load_unified.py``) and adds backend fixtures for the two
+targeting modes:
+
+* **hermetic** — a CI-stood-up backend at ``$COLLIDERML_BACKEND``
+  (docker-compose, mock-SFAPI). Tests skip cleanly if it isn't set.
+* **live** — the deployed backend (``colliderml-backend.onrender.com``),
+  used by the drift-detector lane; warmed for Render free-tier cold start.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from tests.pipeline._http import LIVE_BACKEND_URL, http_get, wait_for_health  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Backend target fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def hermetic_backend() -> str:
+    """URL of a CI-stood-up backend; skip if not provided.
+
+    The pipeline-health workflow sets COLLIDERML_BACKEND=http://localhost:8000
+    after `docker compose up`. Locally: run backend/docker-compose.yml (or
+    scripts/setup_tutorial_env.sh) and export COLLIDERML_BACKEND.
+    """
+    url = os.environ.get("COLLIDERML_BACKEND", "").rstrip("/")
+    if not url or "onrender.com" in url:
+        pytest.skip("no hermetic backend ($COLLIDERML_BACKEND points at localhost compose)")
+    if not wait_for_health(url, deadline_s=60.0):
+        pytest.skip(f"hermetic backend {url} did not become healthy")
+    return url
+
+
+@pytest.fixture(scope="session")
+def live_backend() -> str:
+    """URL of the deployed backend, warmed for cold start."""
+    url = LIVE_BACKEND_URL.rstrip("/")
+    if not wait_for_health(url, deadline_s=90.0):
+        pytest.skip(f"live backend {url} unreachable / did not wake")
+    return url
+
+
+@pytest.fixture
+def hf_token() -> str:
+    """A real HF bearer token, or skip cleanly (for `needs_hf_token` tests)."""
+    tok = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if not tok:
+        pytest.skip("HF_TOKEN not set")
+    return tok
+
+
+@pytest.fixture
+def docker_available() -> str:
+    rt = shutil.which("docker") or shutil.which("podman")
+    if not rt:
+        pytest.skip("no docker/podman runtime on PATH")
+    return rt
+
+
+@pytest.fixture(scope="session")
+def admin_token() -> str:
+    return os.environ.get("ADMIN_TOKEN", "dev-admin-token")
+
+
+# ---------------------------------------------------------------------------
+# Reused mock harnesses
+# ---------------------------------------------------------------------------
+# Lifted from tests/test_remote_client.py so the pipeline suite is self-contained.
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, json_body: Optional[Dict[str, Any]] = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._json_body = json_body if json_body is not None else {}
+        self.text = text or str(self._json_body)
+
+    def json(self) -> Dict[str, Any]:
+        return self._json_body
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise _FakeHTTPError(f"status {self.status_code}")
+
+
+class _FakeHTTPError(Exception):
+    pass
+
+
+class _FakeRequestException(Exception):
+    pass
+
+
+class _FakeRequests:
+    """Minimal stand-in for the `requests` module."""
+
+    RequestException = _FakeRequestException
+
+    def __init__(self) -> None:
+        self.post_calls: List[Dict[str, Any]] = []
+        self.get_calls: List[Dict[str, Any]] = []
+        self.post_response: _FakeResponse = _FakeResponse(200, {"request_id": "stub"})
+        self.get_response: _FakeResponse = _FakeResponse(200, {})
+        self.raise_on_post: Optional[Exception] = None
+
+    def post(self, url, *, json=None, data=None, files=None, headers=None, timeout=None):
+        if self.raise_on_post is not None:
+            raise self.raise_on_post
+        self.post_calls.append(
+            {"url": url, "json": json, "data": data, "files": files, "headers": headers, "timeout": timeout}
+        )
+        return self.post_response
+
+    def get(self, url, *, headers=None, timeout=None):
+        self.get_calls.append({"url": url, "headers": headers, "timeout": timeout})
+        return self.get_response
+
+
+@pytest.fixture
+def fake_requests(monkeypatch: pytest.MonkeyPatch) -> _FakeRequests:
+    """Install a fake `requests` module + stub HF auth; return the fake."""
+    from colliderml.remote import _auth as auth_mod
+    from colliderml.remote import _client as client_mod
+
+    fake = _FakeRequests()
+    monkeypatch.setitem(sys.modules, "requests", fake)  # type: ignore[arg-type]
+    monkeypatch.setattr(auth_mod, "require_hf_token", lambda: "test-token")
+    monkeypatch.setattr(client_mod, "require_hf_token", lambda: "test-token")
+    return fake
+
+
+@pytest.fixture
+def stub_loader(monkeypatch: pytest.MonkeyPatch):
+    """Replace the core loader + cache-ensurance so load tests are pure-Python."""
+    import polars as pl
+
+    from colliderml import _load as load_mod
+
+    calls: Dict[str, object] = {}
+
+    def fake_ensure(channel, pileup, tables, *, dataset_id, revision=None, max_events=None, event_range=None):
+        calls["ensure"] = (channel, pileup, list(tables), dataset_id, revision)
+        calls["ensure_bounds"] = (max_events, event_range)
+
+    stub_frame = pl.DataFrame({"event_id": list(range(10)), "hit_id": list(range(10))})
+
+    def fake_load_tables(cfg):
+        calls["cfg"] = cfg
+        return {"tracker_hits": stub_frame.clone(), "particles": stub_frame.clone()}
+
+    monkeypatch.setattr(load_mod, "_ensure_local", fake_ensure)
+    monkeypatch.setattr(load_mod, "_core_load_tables", fake_load_tables)
+    return calls

--- a/tests/pipeline/test_e2e_core_loop.py
+++ b/tests/pipeline/test_e2e_core_loop.py
@@ -1,0 +1,72 @@
+"""End-to-end: the whole core loop against the CI compose backend (mock-SFAPI).
+
+load -> remote.submit -> wait_for(completed) -> balance dropped -> tasks.evaluate
+-> tasks.submit -> leaderboard read reflects the submission. Green once the
+backend test-auth seam (ALLOW_TEST_TOKEN) lands; skips cleanly without a token
+or a hermetic backend.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+import colliderml
+from tests.pipeline._http import http_get, http_post
+
+pytestmark = [pytest.mark.pipeline, pytest.mark.e2e, pytest.mark.hermetic]
+
+
+def _jets_table(n: int = 12) -> pa.Table:
+    prob_b = [0.05 + 0.9 * (i / (n - 1)) for i in range(n)]
+    prob_c = [(1.0 - p) * 0.4 for p in prob_b]
+    prob_light = [1.0 - b - c for b, c in zip(prob_b, prob_c)]
+    return pa.table({
+        "event_id": list(range(n)), "jet_id": list(range(n)),
+        "prob_b": prob_b, "prob_c": prob_c, "prob_light": prob_light,
+    })
+
+
+def test_core_loop_end_to_end(hermetic_backend, hf_token, admin_token, monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", hf_token)
+
+    # --- learn + fund the CI test user (created on first /v1/me hit) ---
+    bearer = {"Authorization": f"Bearer {hf_token}"}
+    st, me = http_get(f"{hermetic_backend}/v1/me", headers=bearer, timeout=20)
+    assert st == 200, f"/v1/me -> {st}: {me}"
+    username = me["hf_username"]
+    st, _ = http_post(
+        f"{hermetic_backend}/admin/grant",
+        json_body={"hf_username": username, "delta": 1000, "reason": "ci-e2e"},
+        headers={"X-Admin-Token": admin_token}, timeout=20,
+    )
+    assert st == 200, f"/admin/grant -> {st}"
+
+    # --- 1. load public mini-data ---
+    frames = colliderml.load("ttbar_pu0", tables=["particles"], max_events=2)
+    assert frames["particles"].height >= 1
+
+    # --- 2-4. remote submit -> poll -> balance dropped ---
+    from colliderml.remote import balance, submit, wait_for
+
+    before = balance(backend_url=hermetic_backend)
+    sub = submit(channel="higgs_portal", events=10, pileup=0, seed=11, backend_url=hermetic_backend)
+    assert sub.request_id
+    final = wait_for(sub.request_id, backend_url=hermetic_backend, timeout=60, poll_interval=1.0)
+    assert final.state == "completed"
+    assert balance(backend_url=hermetic_backend) <= before
+
+    # --- 5. tasks evaluate (local preview) ---
+    table = _jets_table()
+    assert "btag_auc" in colliderml.tasks.evaluate("jets", table)
+
+    # --- 6. tasks submit ---
+    body = colliderml.tasks.submit("jets", table, backend_url=hermetic_backend)
+    assert "submission_id" in body
+
+    # --- 7. leaderboard reflects the submission ---
+    st, lb = http_get(f"{hermetic_backend}/v1/leaderboard/jets", timeout=20)
+    assert st == 200 and isinstance(lb, list)
+    assert body["submission_id"] in {r.get("id") for r in lb} or any(
+        r.get("hf_username") == username for r in lb
+    )

--- a/tests/pipeline/test_stage_benchmark_tasks.py
+++ b/tests/pipeline/test_stage_benchmark_tasks.py
@@ -1,0 +1,39 @@
+"""Pipeline stage: benchmark-tasks / model-zoo surface.
+
+Asserts the backend task catalogue is well-formed and that the client's
+registered task metadata matches the backend's — catching client/server
+registry skew (the backend scores against the library's task definitions).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import colliderml
+from tests.pipeline._http import http_get
+
+pytestmark = pytest.mark.pipeline
+
+
+@pytest.mark.live
+def test_benchmark_tasks_well_formed(live_backend):
+    status, body = http_get(f"{live_backend}/v1/benchmark/tasks", timeout=30)
+    assert status == 200, f"HTTP {status} — {body}"
+    assert isinstance(body, list) and body
+    for t in body:
+        assert {"name", "metrics", "higher_is_better", "eval_event_range"}.issubset(t)
+        assert len(t["eval_event_range"]) == 2
+
+
+@pytest.mark.hermetic
+def test_client_metadata_matches_backend(hermetic_backend):
+    """The backend's per-task metrics/higher_is_better match the client registry."""
+    status, body = http_get(f"{hermetic_backend}/v1/benchmark/tasks", timeout=20)
+    assert status == 200, f"HTTP {status} — {body}"
+    for t in body:
+        name = t["name"]
+        client = colliderml.tasks.get(name)
+        assert list(t["metrics"]) == list(client.metrics), f"{name}: metrics differ"
+        assert dict(t["higher_is_better"]) == dict(client.higher_is_better), (
+            f"{name}: higher_is_better differs between server and client"
+        )

--- a/tests/pipeline/test_stage_import.py
+++ b/tests/pipeline/test_stage_import.py
@@ -1,0 +1,55 @@
+"""Pipeline stage: import / install.
+
+Contract: ``import colliderml`` is cheap (heavy extras lazy-loaded), the
+public surface resolves, and ``__version__`` is populated.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.pipeline
+
+
+def test_bare_import_is_lazy():
+    """`import colliderml` must not eagerly import the heavy extras.
+
+    Run in a fresh subprocess so other tests in this session (which import
+    colliderml.tasks etc.) don't pollute sys.modules.
+    """
+    code = (
+        "import sys, colliderml; "
+        "assert 'colliderml.tasks' not in sys.modules, 'tasks imported eagerly'; "
+        "assert 'colliderml.simulate' not in sys.modules, 'simulate imported eagerly'; "
+        "print('ok')"
+    )
+    res = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+    assert "ok" in res.stdout
+
+
+def test_lazy_attrs_resolve():
+    import colliderml
+
+    assert callable(colliderml.load)
+    # Accessing each lazy attribute resolves without raising.
+    assert colliderml.tasks is not None
+    assert colliderml.remote is not None
+    assert callable(colliderml.tasks.list_tasks)
+
+
+def test_unknown_attr_raises_attributeerror():
+    import colliderml
+
+    with pytest.raises(AttributeError):
+        _ = colliderml.does_not_exist
+
+
+def test_version_present():
+    import colliderml
+
+    assert isinstance(colliderml.__version__, str)
+    assert colliderml.__version__

--- a/tests/pipeline/test_stage_leaderboard.py
+++ b/tests/pipeline/test_stage_leaderboard.py
@@ -1,0 +1,51 @@
+"""Pipeline stage: leaderboard read.
+
+Hermetic GREEN proves the route + SQL are sound on a freshly-migrated DB.
+Live RED catches the deployment/data defect: ``/v1/leaderboard/{task}`` 500s
+for every task on the deployed backend while ``/v1/benchmark/tasks`` is 200 —
+the contrast localizes the break to deployment, not code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.pipeline._http import http_get
+
+pytestmark = pytest.mark.pipeline
+
+TASKS = ["tracking", "jets", "anomaly", "tracking_latency", "tracking_small", "data_loading"]
+
+
+@pytest.mark.hermetic
+def test_leaderboard_hermetic_returns_list(hermetic_backend):
+    """Every task's leaderboard returns 200 + a JSON list on the compose backend."""
+    for task in TASKS:
+        status, body = http_get(f"{hermetic_backend}/v1/leaderboard/{task}", timeout=20)
+        assert status == 200, f"{task}: HTTP {status} — {body}"
+        assert isinstance(body, list), f"{task}: expected a list, got {type(body)}"
+
+
+@pytest.mark.live
+def test_benchmark_tasks_live_200(live_backend):
+    """The known-good live route — proves the backend is up and lists the tasks."""
+    status, body = http_get(f"{live_backend}/v1/benchmark/tasks", timeout=30)
+    assert status == 200, f"HTTP {status} — {body}"
+    names = {t["name"] for t in body}
+    assert {"tracking", "jets", "anomaly"}.issubset(names)
+
+
+@pytest.mark.live
+def test_leaderboard_live_all_tasks_200(live_backend):
+    """RED: the live leaderboard read must return 200 for every task. Today it 500s."""
+    status, tasks = http_get(f"{live_backend}/v1/benchmark/tasks", timeout=30)
+    names = [t["name"] for t in tasks] if status == 200 and isinstance(tasks, list) else TASKS
+    failures = {}
+    for task in names:
+        s, body = http_get(f"{live_backend}/v1/leaderboard/{task}", timeout=30)
+        if s != 200:
+            failures[task] = (s, str(body)[:120])
+    assert not failures, (
+        f"GET /v1/leaderboard/<task> not 200 for: {failures} — "
+        f"fix the deployed leaderboard read path (backend/app/leaderboard.py)."
+    )

--- a/tests/pipeline/test_stage_load.py
+++ b/tests/pipeline/test_stage_load.py
@@ -1,0 +1,49 @@
+"""Pipeline stage: load data.
+
+Contract: ``colliderml.load("<channel>_pu<N>")`` returns a dict of frames
+keyed by table name, requesting the default object tables. The real
+public-data load (no token) is a separate `integration` check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import colliderml
+
+pytestmark = pytest.mark.pipeline
+
+
+def test_load_contract_returns_named_frames(stub_loader):
+    """Mock tier: load() returns frames keyed by table, default tables requested."""
+    frames = colliderml.load("ttbar_pu0")
+    assert set(frames) == {"tracker_hits", "particles"}
+    # default object tables were requested through the cache-ensurance layer
+    _, _, requested_tables, dataset_id, _ = stub_loader["ensure"]
+    assert requested_tables == list(colliderml.DEFAULT_OBJECT_TABLES)
+    assert dataset_id  # a dataset id was resolved
+
+
+def test_load_parses_channel_and_pileup(stub_loader):
+    colliderml.load("higgs_portal_pu200", tables=["particles"], max_events=5)
+    channel, pileup, tables, _, _ = stub_loader["ensure"]
+    assert channel == "higgs_portal"
+    assert pileup == "pu200"
+    assert tables == ["particles"]
+    assert stub_loader["ensure_bounds"][0] == 5  # max_events threaded through
+
+
+def test_load_rejects_malformed_dataset_name(stub_loader):
+    with pytest.raises(ValueError):
+        colliderml.load("not-a-valid-name")
+
+
+@pytest.mark.integration
+def test_load_real_public_data():
+    """Real load against the PUBLIC CERN/ColliderML-Release-1 (no token)."""
+    frames = colliderml.load("ttbar_pu0", tables=["particles"], max_events=2)
+    assert "particles" in frames
+    part = frames["particles"]
+    # eager polars frame with an event_id column and at least one event
+    assert "event_id" in part.columns
+    assert part.height >= 1

--- a/tests/pipeline/test_stage_simulate_local.py
+++ b/tests/pipeline/test_stage_simulate_local.py
@@ -1,0 +1,59 @@
+"""Pipeline stage: simulate locally.
+
+Mock tier asserts the dispatch/validation contract; the `sim` smoke runs a
+real 2-event pipeline (skips without a container runtime). The RED test pins
+the half-removed ``single_muon`` channel.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from colliderml.simulate.pipeline import CHANNEL_STAGES
+
+pytestmark = pytest.mark.pipeline
+
+
+def test_channel_stages_known():
+    """The two fully-supported channels expose pipeline stages."""
+    assert "ttbar" in CHANNEL_STAGES
+    assert "higgs_portal" in CHANNEL_STAGES
+    assert len(CHANNEL_STAGES["ttbar"]) >= 3
+
+
+def test_simulate_requires_channel_or_preset():
+    """simulate() with neither preset nor channel must fail fast (pre-Docker)."""
+    from colliderml.simulate.api import simulate
+
+    with pytest.raises((ValueError, TypeError)):
+        simulate()
+
+
+def test_single_muon_not_simulatable():
+    """RED: single_muon's preset was removed and its Pythia stage-routing is
+    wrong (it needs an ACTS particle-gun stage), so it must NOT be offered as a
+    simulatable channel until that exists. Today it is still in CHANNEL_STAGES.
+    """
+    assert "single_muon" not in CHANNEL_STAGES, (
+        "single_muon is still a simulatable channel but its preset was removed "
+        "and it is routed through Pythia (wrong); remove it from CHANNEL_STAGES "
+        "(simulate/pipeline.py) or add a proper particle-gun stage."
+    )
+
+
+@pytest.mark.sim
+@pytest.mark.slow
+def test_simulate_two_events_smoke(docker_available, tmp_path):
+    """Real 2-event higgs_portal run (needs Docker/Podman + the ODD image)."""
+    from colliderml.simulate.api import simulate
+
+    result = simulate(
+        channel="higgs_portal",
+        events=2,
+        pileup=0,
+        output_dir=tmp_path,
+        runtime=docker_available,
+        quiet=True,
+    )
+    assert result.channel == "higgs_portal"
+    assert any(p.suffix == ".parquet" for p in result.list_files())

--- a/tests/pipeline/test_stage_simulate_remote.py
+++ b/tests/pipeline/test_stage_simulate_remote.py
@@ -1,0 +1,74 @@
+"""Pipeline stage: simulate remotely (SaaS client).
+
+Mock tier asserts the submit/poll HTTP contract. The RED test asserts the
+*shipped default* backend host resolves. Hermetic tier drives a real
+submit→wait_for against the CI compose backend (mock-SFAPI).
+"""
+
+from __future__ import annotations
+
+import importlib
+import socket
+from urllib.parse import urlparse
+
+import pytest
+
+pytestmark = pytest.mark.pipeline
+
+
+def test_submit_posts_to_v1_simulate(fake_requests):
+    """Mock: remote.submit() POSTs /v1/simulate with the request payload + bearer."""
+    from colliderml.remote import submit
+
+    fake_requests.post_response = type(fake_requests.post_response)(
+        200,
+        {
+            "request_id": "r-1",
+            "state": "submitted",
+            "channel": "ttbar",
+            "events": 10,
+            "pileup": 0,
+            "credits_charged": 1.0,
+        },
+    )
+    sub = submit(channel="ttbar", events=10, pileup=0, seed=42, backend_url="http://test")
+    assert sub.request_id == "r-1"
+    call = fake_requests.post_calls[-1]
+    assert call["url"].endswith("/v1/simulate")
+    assert call["json"] == {"channel": "ttbar", "events": 10, "pileup": 0, "seed": 42}
+    assert "Authorization" in (call["headers"] or {})
+
+
+def test_default_backend_is_reachable(monkeypatch):
+    """RED: the backend URL the library ships by default must resolve via DNS.
+
+    Re-derive the *shipped* default (env unset) so a CI COLLIDERML_BACKEND
+    override can't mask the dead host. Today it is api.colliderml.com (NXDOMAIN).
+    """
+    import colliderml.remote._client as client_mod
+
+    monkeypatch.delenv("COLLIDERML_BACKEND", raising=False)
+    importlib.reload(client_mod)
+    try:
+        host = urlparse(client_mod.DEFAULT_BACKEND_URL).hostname
+        try:
+            socket.getaddrinfo(host, 443)
+        except socket.gaierror as e:
+            pytest.fail(
+                f"shipped default backend host {host!r} does not resolve ({e}); "
+                f"repoint DEFAULT_BACKEND_URL in colliderml/remote/_client.py."
+            )
+    finally:
+        importlib.reload(client_mod)  # restore env-derived value for other tests
+
+
+@pytest.mark.hermetic
+def test_submit_wait_for_hermetic(hermetic_backend, hf_token, monkeypatch):
+    """Real submit→wait_for against the compose backend (mock-SFAPI completes ~2s)."""
+    monkeypatch.setenv("HF_TOKEN", hf_token)
+    from colliderml.remote import submit, wait_for
+
+    sub = submit(channel="higgs_portal", events=10, pileup=0, seed=7, backend_url=hermetic_backend)
+    assert sub.request_id
+    final = wait_for(sub.request_id, backend_url=hermetic_backend, timeout=60, poll_interval=1.0)
+    assert final.state == "completed"

--- a/tests/pipeline/test_stage_tasks_evaluate.py
+++ b/tests/pipeline/test_stage_tasks_evaluate.py
@@ -1,0 +1,88 @@
+"""Pipeline stage: tasks evaluate (local preview scoring).
+
+GREEN: registry + schema validation + metric dict. RED: jets/anomaly local
+scoring is not grounded in canonical truth — jets pairs predictions to a
+fixed-RNG truth positionally, and anomaly derives truth from the submitter's
+own ``channel`` column. Both are encoded as contract assertions that fail now.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+import colliderml
+
+pytestmark = pytest.mark.pipeline
+
+
+EXPECTED_TASKS = {"tracking", "jets", "anomaly", "tracking_latency", "tracking_small", "data_loading"}
+
+
+def test_registry_lists_all_tasks():
+    assert set(colliderml.tasks.list_tasks()) == EXPECTED_TASKS
+
+
+def test_evaluate_rejects_bad_schema():
+    bad = pa.table({"event_id": [1, 2], "jet_id": [0, 1]})  # missing prob_* columns
+    with pytest.raises(ValueError):
+        colliderml.tasks.evaluate("jets", bad)
+
+
+def test_evaluate_returns_metric_dict():
+    preds = _jets_table(event_ids=list(range(20)))
+    scores = colliderml.tasks.evaluate("jets", preds)
+    assert set(scores) == {"btag_auc", "light_rej_70", "c_rej_70"}
+    assert all(isinstance(v, float) for v in scores.values())
+
+
+def test_jets_score_is_by_identity_not_row_order():
+    """RED: scoring must join predictions to truth by (event_id, jet_id), so
+    shuffling the prediction rows must NOT change the score. Today jets pairs
+    predictions to a fixed-RNG truth positionally, so a shuffle changes it.
+    """
+    preds = _jets_table(event_ids=list(range(20)))
+    shuffled = preds.take(list(range(19, -1, -1)))  # reverse row order
+    a = colliderml.tasks.evaluate("jets", preds)["btag_auc"]
+    b = colliderml.tasks.evaluate("jets", shuffled)["btag_auc"]
+    assert a == pytest.approx(b), (
+        "jets score changed when prediction rows were reordered — it is paired "
+        "to truth positionally (fixed RNG) instead of joined by event_id/jet_id "
+        "against canonical truth (colliderml/tasks/jets/task.py)."
+    )
+
+
+def test_anomaly_score_ignores_self_supplied_labels():
+    """RED: AUROC must use canonical truth (which events are really BSM), not the
+    submitter's own ``channel`` column. Today a user controls their own truth, so
+    merely relabeling channels flips the AUROC — it must be invariant instead.
+    """
+    scores = [0.9 - 0.04 * i for i in range(20)]
+    eids = list(range(20))
+    bsm, sm = "zprime_pu0", "ttbar_pu0"
+    # t1: high scores labeled BSM (cheats to AUROC~1); t2: labels reversed (~0)
+    t1 = pa.table({"event_id": eids, "anomaly_score": scores,
+                   "channel": [bsm] * 10 + [sm] * 10})
+    t2 = pa.table({"event_id": eids, "anomaly_score": scores,
+                   "channel": [sm] * 10 + [bsm] * 10})
+    a = colliderml.tasks.evaluate("anomaly", t1)["auroc"]
+    b = colliderml.tasks.evaluate("anomaly", t2)["auroc"]
+    assert a == pytest.approx(b), (
+        "anomaly AUROC changed when the submitter relabeled the 'channel' column — "
+        "truth is taken from user input instead of canonical labels "
+        "(colliderml/tasks/anomaly/task.py)."
+    )
+
+
+def _jets_table(event_ids):
+    n = len(event_ids)
+    prob_b = [0.05 + 0.9 * (i / max(n - 1, 1)) for i in range(n)]
+    prob_c = [(1.0 - p) * 0.4 for p in prob_b]
+    prob_light = [1.0 - b - c for b, c in zip(prob_b, prob_c)]
+    return pa.table({
+        "event_id": list(event_ids),
+        "jet_id": list(range(n)),
+        "prob_b": prob_b,
+        "prob_c": prob_c,
+        "prob_light": prob_light,
+    })

--- a/tests/pipeline/test_stage_tasks_submit.py
+++ b/tests/pipeline/test_stage_tasks_submit.py
@@ -1,0 +1,51 @@
+"""Pipeline stage: tasks submit (remote scoring + leaderboard write).
+
+GREEN (mock): submit() posts the parquet + local scores to
+``/v1/benchmark/<task>/submit`` with a bearer token, and surfaces backend
+errors. Hermetic: a real round-trip against the compose backend.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+import colliderml
+
+pytestmark = pytest.mark.pipeline
+
+
+def _jets_table(n: int = 12) -> pa.Table:
+    prob_b = [0.05 + 0.9 * (i / (n - 1)) for i in range(n)]
+    prob_c = [(1.0 - p) * 0.4 for p in prob_b]
+    prob_light = [1.0 - b - c for b, c in zip(prob_b, prob_c)]
+    return pa.table({
+        "event_id": list(range(n)), "jet_id": list(range(n)),
+        "prob_b": prob_b, "prob_c": prob_c, "prob_light": prob_light,
+    })
+
+
+def test_submit_posts_multipart(fake_requests):
+    fake_requests.post_response = type(fake_requests.post_response)(
+        200, {"submission_id": "s-1", "scores": {"btag_auc": 0.9}, "credits_earned": 0.0}
+    )
+    body = colliderml.tasks.submit("jets", _jets_table(), backend_url="http://test")
+    assert body["submission_id"] == "s-1"
+    call = fake_requests.post_calls[-1]
+    assert call["url"].endswith("/v1/benchmark/jets/submit")
+    assert "predictions" in (call["files"] or {})
+    assert "local_scores" in (call["data"] or {})
+    assert "Authorization" in (call["headers"] or {})
+
+
+def test_submit_raises_on_backend_error(fake_requests):
+    fake_requests.post_response = type(fake_requests.post_response)(500, {}, text="boom")
+    with pytest.raises(RuntimeError):
+        colliderml.tasks.submit("jets", _jets_table(), backend_url="http://test")
+
+
+@pytest.mark.hermetic
+def test_submit_hermetic_roundtrip(hermetic_backend, hf_token, monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", hf_token)
+    body = colliderml.tasks.submit("jets", _jets_table(), backend_url=hermetic_backend)
+    assert "submission_id" in body and "scores" in body


### PR DESCRIPTION
Adds rigorous tests for **each core-loop stage** (import → load → simulate → tasks → leaderboard → model-zoo) plus **one end-to-end chain**, written as positive contract assertions so they are **RED today exactly where the platform is broken**. Surfaced as a **non-blocking dashboard** (`pipeline-health.yml`), never a merge gate.

### What's here
- `tests/pipeline/` — one module per stage + `test_e2e_core_loop.py` + `conftest` (reuses the existing `_FakeRequests`/`stub_loader` harnesses).
- `pytest.ini` — markers `pipeline/e2e/live/hermetic/sim/needs_hf_token`.
- `pipeline-health.yml` — hermetic lane (docker-compose backend, mock-SFAPI, `ALLOW_TEST_TOKEN`) on PRs/nightly + live drift lane (deployed backend) nightly/manual; per-stage red/green via JUnit; `continue-on-error`.
- `tests.yml` — excludes `-m pipeline` so the red dashboard never blocks merges.

### Verified locally (the worklist)
4 RED in the mock lane + 1 RED in the live lane:
1. `simulate_remote::test_default_backend_is_reachable` — `api.colliderml.com` NXDOMAIN
2. `simulate_local::test_single_muon_not_simulatable` — half-removed channel still in `CHANNEL_STAGES`
3. `tasks_evaluate::test_jets_score_is_by_identity_not_row_order` — fixed-RNG truth
4. `tasks_evaluate::test_anomaly_score_ignores_self_supplied_labels` — truth from user's own `channel` (AUROC flips 1.0↔0.0 on relabel)
5. `leaderboard::test_leaderboard_live_all_tasks_200` — deployed `/v1/leaderboard/{task}` 500s for all 6 tasks

Everything else green. The hermetic e2e goes green once the backend test-auth seam lands (OpenDataDetector/colliderml-production `tests/pipeline-ci`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)