### PR TITLE
fix: repoint default backend host + drop half-removed single_muon

### DIFF
--- a/colliderml/cli.py
+++ b/colliderml/cli.py
@@ -326,7 +326,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_bal.add_argument(
         "--backend-url",
         default=None,
-        help="Override the backend URL (default: $COLLIDERML_BACKEND or https://api.colliderml.com).",
+        help="Override the backend URL (default: $COLLIDERML_BACKEND or https://colliderml-backend.onrender.com).",
     )
     p_bal.add_argument(
         "--json",

--- a/colliderml/remote/_client.py
+++ b/colliderml/remote/_client.py
@@ -18,7 +18,7 @@ from colliderml.remote._auth import auth_headers, require_hf_token
 #: Default backend URL. Overridable with ``$COLLIDERML_BACKEND`` or the
 #: ``backend_url=`` keyword on every client entry point.
 DEFAULT_BACKEND_URL = os.environ.get(
-    "COLLIDERML_BACKEND", "https://api.colliderml.com"
+    "COLLIDERML_BACKEND", "https://colliderml-backend.onrender.com"
 )
 
 #: Interval between poll cycles in :func:`wait_for`.

--- a/colliderml/simulate/pipeline.py
+++ b/colliderml/simulate/pipeline.py
@@ -106,26 +106,10 @@ CHANNEL_STAGES: Dict[str, Tuple[Stage, ...]] = {
             config="digitization_config.yaml",
         ),
     ),
-    "single_muon": (
-        Stage(
-            name="Pythia Generation",
-            stage="pythia_generation",
-            script="simulation/pythia_gen.py",
-            config="pythia_config.yaml",
-        ),
-        Stage(
-            name="Detector Simulation",
-            stage="simulation",
-            script="simulation/ddsim_run.py",
-            config="simulation_config.yaml",
-        ),
-        Stage(
-            name="Digitization & Reconstruction",
-            stage="digitization",
-            script="simulation/digi_and_reco.py",
-            config="digitization_config.yaml",
-        ),
-    ),
+    # NOTE: `single_muon` is intentionally absent. Its preset was removed and it
+    # was mis-routed through Pythia generation (it needs an ACTS particle-gun
+    # stage, not a hard-process generator). Re-add it only with a correct
+    # particle-gun pipeline.
 }
 
 

--- a/tests/test_simulate_api.py
+++ b/tests/test_simulate_api.py
@@ -36,7 +36,6 @@ def test_simulate_rejects_unknown_channel() -> None:
 def test_get_channel_stages_includes_known_channels() -> None:
     assert get_channel_stages("ttbar")
     assert get_channel_stages("higgs_portal")
-    assert get_channel_stages("single_muon")
 
 
 def _install_simulate_stubs(


### PR DESCRIPTION
Knocks down two pipeline-health reds (audit launch-blockers): repoint `DEFAULT_BACKEND_URL` from the dead `api.colliderml.com` to `colliderml-backend.onrender.com` (remote/_client.py + cli.py), and remove `single_muon` from `CHANNEL_STAGES` (preset removed + wrong Pythia routing). Verified: both reds now green in the mock lane. 🤖 Generated with [Claude Code](https://claude.com/claude-code)