### PR TITLE
release: 0.4.2 (version bump + sdist cleanup + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.4.2] - 2026-06-28
+
+### Fixed
+- [library] Default backend URL repointed from the dead `api.colliderml.com` (NXDOMAIN) to the live host, so out-of-the-box `colliderml.remote.*` / `colliderml.tasks.submit(...)` calls reach the SaaS backend. Override with `$COLLIDERML_BACKEND` as before.
+- [library] Removed the phantom `single_muon` simulation channel: it had no released dataset config and was mis-routed through Pythia generation (it needs an ACTS particle-gun stage). It now errors cleanly instead of silently running a wrong pipeline.
+
+### Changed
+- [library] `simulate` uses the native-Arrow OpenDataDetector v5.0.0 image and drops the separate parquet-conversion stage (digitization writes parquet directly).
+- [packaging] The `docs/` VitePress site is no longer bundled into the sdist (it had pulled ~5 MB of detector images / event JSON and a local `node_modules` into the source distribution).
+
 ## [0.4.1] - 2026-05-27
 
 ### Fixed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,12 @@ include LICENSE
 include README.md
 include setup.cfg
 recursive-include tests *
-recursive-include docs *
 recursive-include colliderml/simulate *.yaml
+# The VitePress site (docs/) is NOT part of the Python package — it pulled
+# ~5 MB of detector images / event JSON (and a local node_modules with
+# esbuild/TypeScript binaries) into the sdist. Keep it out.
+prune docs
 global-exclude *.py[cod]
 global-exclude __pycache__
 global-exclude *.so
+global-exclude node_modules

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="colliderml",
-    version="0.4.1",
+    version="0.4.2",
     description="A modern machine learning library for high-energy physics data analysis",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Prep for the 0.4.2 release that ships the dead-host + single_muon fixes.

- **Version** 0.4.1 → 0.4.2 (the publish workflow builds from setup.py, so this is required or it would rebuild 0.4.1 and fail on PyPI).
- **sdist cleanup**: `MANIFEST.in` no longer `recursive-include docs *` — it swept ~5 MB of detector images / event JSON (and locally a `node_modules` with esbuild/TS binaries) into the sdist (**34 MB → 106 KB**). Wheel was already clean (91 KB).
- **CHANGELOG** 0.4.2 entry.

Verified: `twine check` passes both artifacts; a clean-venv install of the 0.4.2 wheel imports simulate/remote/tasks, loads presets, repoints the default backend, and drops single_muon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)