### PR TITLE
tests(pipeline): SFAPI drift check via public /v1/sfapi/health (no token)

### DIFF
--- a/.github/workflows/pipeline-health.yml
+++ b/.github/workflows/pipeline-health.yml
@@ -104,7 +104,7 @@ jobs:
         continue-on-error: true
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}    # auth'd live tests skip if empty
-          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}  # for /admin/sfapi/health; test skips if empty
+          # (the SFAPI drift check needs no token — /v1/sfapi/health is public)
         run: |
           PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -v -p no:cacheprovider \
             -m "live" tests/pipeline --junitxml=pipeline-live.xml

--- a/tests/pipeline/test_stage_sfapi.py
+++ b/tests/pipeline/test_stage_sfapi.py
@@ -3,15 +3,14 @@
 Real simulation breaks silently if the deployed backend's egress IP drifts out
 of the NERSC-registered allowlist, or its SFAPI credentials expire. CI can't
 test SFAPI directly — a GitHub runner's IP isn't allowlisted, so it would 403.
-Instead we ask the backend's `/admin/sfapi/health`, which runs the check from
-the only allowlisted vantage point (the backend itself).
+Instead we ask the backend's public ``/v1/sfapi/health``, which runs the check
+from the only allowlisted vantage point (the backend itself).
 
-Needs the prod admin token (`$ADMIN_TOKEN`); skips cleanly without it.
+The endpoint is intentionally unauthenticated and returns only non-sensitive
+health signals, so this needs **no token** — safe for the public repo's CI.
 """
 
 from __future__ import annotations
-
-import os
 
 import pytest
 
@@ -20,20 +19,8 @@ from tests.pipeline._http import http_get
 pytestmark = [pytest.mark.pipeline, pytest.mark.live]
 
 
-@pytest.fixture
-def admin_token() -> str:
-    t = os.environ.get("ADMIN_TOKEN")
-    if not t:
-        pytest.skip("ADMIN_TOKEN not set (needed for /admin/sfapi/health)")
-    return t
-
-
-def test_sfapi_egress_in_allowlist_and_reachable(live_backend, admin_token):
-    status, body = http_get(
-        f"{live_backend}/admin/sfapi/health",
-        headers={"X-Admin-Token": admin_token},
-        timeout=45,
-    )
+def test_sfapi_egress_in_allowlist_and_reachable(live_backend):
+    status, body = http_get(f"{live_backend}/v1/sfapi/health", timeout=45)
     assert status == 200, f"HTTP {status} — {body}"
     assert isinstance(body, dict), body
     assert body.get("mock_mode") is False, (


### PR DESCRIPTION
Pairs with colliderml-production#49: the live SFAPI drift stage now hits the public `/v1/sfapi/health` and needs **no token** (dropped `ADMIN_TOKEN` from the live lane). Safe for the public repo's CI. 🤖 Generated with [Claude Code](https://claude.com/claude-code)